### PR TITLE
add omi.js devtools links to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ English | [简体中文](./README.CN.md)
 - Shadow DOM merges with Virtual DOM, Omi uses both virtual DOM and real Shadow DOM to make view updates more accurate and faster
 - With a Store system, 99.9% of projects don't need time travel, and not only Redux can travel, please don't come up on redux, Omi store system can meet all projects
 - Scoped CSS's best solution is Shadow DOM, the community churning out frameworks and libraries for Scoped CSS (using JS or JSON writing styles such as Radium, jsxstyle, react-style; binding to webpack using generated unique className `filename-classname-hash', such as CSS Modules, Vue), are hack technologies; and Shadow DOM Style is the perfect solution.
+- [Chrome DevTools Extension](https://github.com/f/omi-devtools)
 
 Compare TodoApp by Omi and React, Omi and React rendering DOM structure:
 
@@ -428,6 +429,7 @@ You can dynamically load the JS of this project in the IE9 environment, and the 
 
 - [westore](https://github.com/dntzhang/westore)
 - [omijs.org](http://omijs.org/)
+- [Omi.js DevTools](https://github.com/f/omi-devtools)
 
 ## License
 


### PR DESCRIPTION
Hi @dntzhang!

I created a simple yet useful Chrome DevTools extension for Omi, and added to the README! Please inspect: https://github.com/f/omi-devtools

It simply uses the Element panel's sidebar since Omi uses shadow dom and doesn't need another elements view such as React or Vue have. This makes it powerful while debugging.

<img src="https://raw.githubusercontent.com/f/omi-devtools/master/screenshot.png"/>