### PR TITLE
use textContent instead of innerText to avoid <br> creations

### DIFF
--- a/packages/omi/src/util.js
+++ b/packages/omi/src/util.js
@@ -39,7 +39,7 @@
 
 export function cssToDom(css) {
 	const node = document.createElement('style')
-	node.innerText = css
+	node.textContent = css
 	return node
 }
 


### PR DESCRIPTION
Using `innerText` will try to render the content as following:

<img width="340" alt="screenshot 2018-10-20 17 18 09" src="https://user-images.githubusercontent.com/196477/47256655-4a307600-d48c-11e8-8c3b-2ecb841fea0c.png">

`textContent` is a lower API that doesn't enter to renderer:

<img width="333" alt="screenshot 2018-10-20 17 19 18" src="https://user-images.githubusercontent.com/196477/47256664-70eeac80-d48c-11e8-9c4e-d4fcc27f99a7.png">
