### PR TITLE
fixed remove line-break bug in OSX

### DIFF
--- a/packages/omi-cli/lib/init.js
+++ b/packages/omi-cli/lib/init.js
@@ -40,7 +40,7 @@ function init(args) {
 		process.stdin.resume();
 		process.stdin.setEncoding("utf-8");
 		process.stdin.on("data", chunk => {
-			chunk = chunk.replace(/\s\n|\r\n/g, "");
+			chunk = chunk.replace(/\s\n|\r\n|\n/g, "");
 			if (chunk !== "y" && chunk !== "Y") {
 				process.exit(0);
 			} else {


### PR DESCRIPTION
**Description**
When I command `omi init` to not empty folder in OSX, it is not working to create Omi project. 
The reason why it will ask **This directory isn't empty, empty it? [Y/N]** and user put 'Y' or 'y', but normally in OSX, when user put enter, it will add **\n**, but in the replace code there is nothing check for **\n**

In addition, as I checked, (Reference: [Is a new line = \n OR \r\n?](https://stackoverflow.com/questions/4824621/is-a-new-line-n-or-r-n?answertab=active#tab-top))
- `\n` is used for Unix systems (including Linux, and OSX).

- `\r\n` is mainly used on Windows.

- `\r` is used on really old Macs.

- `PHP_EOL` constant is used instead of these characters for portability between platforms.

So I added `\n` on the replace code.