### PR TITLE
Save project name on package.json

### DIFF
--- a/packages/omi-cli/lib/init.js
+++ b/packages/omi-cli/lib/init.js
@@ -80,6 +80,11 @@ function init(args) {
 					renameSync(join(dest, "gitignore"), join(dest, ".gitignore"));
 					if (customPrjName) {
 						try {
+							const appPackage = require(join(dest,"package.json"));
+							appPackage.name = customPrjName;
+							fs.writeFile(join(dest,"package.json"), JSON.stringify(appPackage, null, 2), (err) => {
+								if (err) return console.log(err);
+							})
 							process.chdir(customPrjName);
 						} catch (err) {
 							console.log(error(err));


### PR DESCRIPTION
Hi, I've found some bugs at omi-cli.

When I create omi project with omi-cli, project name doesn't change at package.json like this.
![2018-10-29 4 27 18](https://user-images.githubusercontent.com/44221844/47635192-82743a80-db97-11e8-8f8b-f9f43846338f.png)
This is my screen shot after I run `omi init text` 
I think it is bug, so I fix it package.json name is same as project name like this.
Sorry for my poor English. If you can't understand, leave a comment. Thx!