### PR TITLE
fix wrong node package module path

### DIFF
--- a/packages/omi-cli/lib/init-pr.js
+++ b/packages/omi-cli/lib/init-pr.js
@@ -68,7 +68,7 @@ function initPr(args) {
 		);
 
 		vfs
-			.src(["**/*", "!mode_modules/**/*"], {
+			.src(["**/*", "!node_modules/**/*"], {
 				cwd: tpl,
 				cwdbase: true,
 				dot: true

--- a/packages/omi-cli/lib/init-ts.js
+++ b/packages/omi-cli/lib/init-ts.js
@@ -67,7 +67,7 @@ function init(args) {
 		);
 
 		vfs
-			.src(["**/*", "!mode_modules/**/*"], {
+			.src(["**/*", "!node_modules/**/*"], {
 				cwd: tpl,
 				cwdbase: true,
 				dot: true


### PR DESCRIPTION
There are **two more places**  have wrong path of node_modules path
- as-is: **mode**_modules
- to-be: **node**_modules