### PR TITLE
omi-cli not to empty a directory, only verify valid a directory instead

### DIFF
--- a/packages/omi-cli/lib/init-pr.js
+++ b/packages/omi-cli/lib/init-pr.js
@@ -12,6 +12,7 @@ var error = logger.error;
 var success = logger.success;
 var isCnFun = require("./utils").isCnFuc;
 var emptyFs = require("./utils").emptyFs;
+var isSafeToCreateProjectIn = require("./utils").isSafeToCreateProjectIn;
 
 function initPr(args) {
 	var omiCli = chalk.bold.cyan("Omi-Cli");
@@ -30,32 +31,13 @@ function initPr(args) {
 				? " will execute init-pr command... "
 				: " 即将执行 init-pr 命令...")
 	);
-
 	if (existsSync(dest) && !emptyDir.sync(dest)) {
-		console.log();
-		process.stdout.write(
-			!isCn
-				? "This directory isn't empty, empty it? [Y/N] "
-				: "此文件夹不为空，是否需要清空？ [Y/N]: "
-		);
-		process.stdin.resume();
-		process.stdin.setEncoding("utf-8");
-		process.stdin.on("data", chunk => {
-			chunk = chunk.replace(/\s\n|\r\n/g, "");
-			if (chunk !== "y" && chunk !== "Y") {
-				process.exit(0);
-			} else {
-				console.log(
-					chalk.bold.cyan("Omi-Cli") +
-						(!isCn ? " is emptying this directory..." : " 正在清空此文件夹...")
-				);
-				emptyFs(dest);
-				createPr();
-			}
-		});
-	} else {
-		createPr();
+		if (!isSafeToCreateProjectIn(dest, projectName)) {
+			process.exit(1);
+		}
 	}
+		
+	createPr();
 
 	function createPr() {
 		console.log();

--- a/packages/omi-cli/lib/init-ts.js
+++ b/packages/omi-cli/lib/init-ts.js
@@ -13,6 +13,7 @@ var error = require("./logger").error;
 var success = require("./logger").success;
 var isCnFun = require("./utils").isCnFuc;
 var emptyFs = require("./utils").emptyFs;
+var isSafeToCreateProjectIn = require("./utils").isSafeToCreateProjectIn;
 
 function init(args) {
 	var omiCli = chalk.bold.cyan("Omi-Cli");
@@ -29,32 +30,13 @@ function init(args) {
 		omiCli +
 			(!isCn ? " will execute init command... " : " 即将执行 init 命令...")
 	);
-
 	if (existsSync(dest) && !emptyDir.sync(dest)) {
-		console.log();
-		process.stdout.write(
-			!isCn
-				? "This directory isn't empty, empty it? [Y/N] "
-				: "此文件夹不为空，是否需要清空？ [Y/N]: "
-		);
-		process.stdin.resume();
-		process.stdin.setEncoding("utf-8");
-		process.stdin.on("data", chunk => {
-			chunk = chunk.replace(/\s\n|\r\n/g, "");
-			if (chunk !== "y" && chunk !== "Y") {
-				process.exit(0);
-			} else {
-				console.log(
-					chalk.bold.cyan("Omi-Cli") +
-						(!isCn ? " is emptying this directory..." : " 正在清空此文件夹...")
-				);
-				emptyFs(dest);
-				createApp();
-			}
-		});
-	} else {
-		createApp();
+		if (!isSafeToCreateProjectIn(dest, projectName)) {
+			process.exit(1);
+		}
 	}
+		
+	createApp();
 
 	function createApp() {
 		console.log();

--- a/packages/omi-cli/lib/init.js
+++ b/packages/omi-cli/lib/init.js
@@ -13,6 +13,7 @@ var error = require("./logger").error;
 var success = require("./logger").success;
 var isCnFun = require("./utils").isCnFuc;
 var emptyFs = require("./utils").emptyFs;
+var isSafeToCreateProjectIn = require("./utils").isSafeToCreateProjectIn;
 
 function init(args) {
 	var omiCli = chalk.bold.cyan("Omi-Cli");
@@ -29,32 +30,13 @@ function init(args) {
 		omiCli +
 			(!isCn ? " will execute init command... " : " 即将执行 init 命令...")
 	);
-
 	if (existsSync(dest) && !emptyDir.sync(dest)) {
-		console.log();
-		process.stdout.write(
-			!isCn
-				? "This directory isn't empty, empty it? [Y/N] "
-				: "此文件夹不为空，是否需要清空？ [Y/N]: "
-		);
-		process.stdin.resume();
-		process.stdin.setEncoding("utf-8");
-		process.stdin.on("data", chunk => {
-			chunk = chunk.replace(/\s\n|\r\n|\n/g, "");
-			if (chunk !== "y" && chunk !== "Y") {
-				process.exit(0);
-			} else {
-				console.log(
-					chalk.bold.cyan("Omi-Cli") +
-						(!isCn ? " is emptying this directory..." : " 正在清空此文件夹...")
-				);
-				emptyFs(dest);
-				createApp();
-			}
-		});
-	} else {
-		createApp();
+		if (!isSafeToCreateProjectIn(dest, projectName)) {
+			process.exit(1);
+		}
 	}
+		
+	createApp();
 
 	function createApp() {
 		console.log();

--- a/packages/omi-cli/lib/utils.js
+++ b/packages/omi-cli/lib/utils.js
@@ -1,4 +1,6 @@
 var fs = require("fs");
+var chalk = require('chalk');
+var path = require('path');
 var existsSync = fs.existsSync;
 var readdirSync = fs.readdirSync;
 var rmdirSync = fs.rmdirSync;
@@ -29,7 +31,79 @@ function emptyFs(path) {
 	}
 }
 
+/**
+ * isSafeToCreateProjectIn function is created from `create-react-app`
+ * which is on create-react-app/packages/create-react-app/createReactApp.js line 740 of version 2.0.4
+ */
+function isSafeToCreateProjectIn(root, name) {
+	// These files should be allowed to remain on a failed install,
+	// but then silently removed during the next create.
+	const errorLogFilePatterns = [
+		'npm-debug.log',
+		'yarn-error.log',
+		'yarn-debug.log',
+	];
+
+  const validFiles = [
+    '.DS_Store',
+    'Thumbs.db',
+    '.git',
+    '.gitignore',
+    '.idea',
+    'README.md',
+    'LICENSE',
+    'web.iml',
+    '.hg',
+    '.hgignore',
+    '.hgcheck',
+    '.npmignore',
+    'mkdocs.yml',
+    'docs',
+    '.travis.yml',
+    '.gitlab-ci.yml',
+    '.gitattributes',
+  ];
+  console.log();
+
+  const conflicts = fs
+    .readdirSync(root)
+    .filter(file => !validFiles.includes(file))
+    // Don't treat log files from previous installation as conflicts
+    .filter(
+      file => !errorLogFilePatterns.some(pattern => file.indexOf(pattern) === 0)
+    );
+
+  if (conflicts.length > 0) {
+    console.log(
+      `The directory ${chalk.green(name)} contains files that could conflict:`
+    );
+    console.log();
+    for (const file of conflicts) {
+      console.log(`  ${file}`);
+    }
+    console.log();
+    console.log(
+      'Either try using a new directory name, or remove the files listed above.'
+    );
+
+    return false;
+  }
+
+  // Remove any remnant files from a previous installation
+  const currentFiles = fs.readdirSync(path.join(root));
+  currentFiles.forEach(file => {
+    errorLogFilePatterns.forEach(errorLogFilePattern => {
+      // This will catch `(npm-debug|yarn-error|yarn-debug).log*` files
+      if (file.indexOf(errorLogFilePattern) === 0) {
+        unlinkSync(path.join(root, file));
+      }
+    });
+  });
+  return true;
+}
+
 module.exports = {
 	isCnFuc: isCnFuc,
-	emptyFs: emptyFs
+	emptyFs: emptyFs,
+	isSafeToCreateProjectIn: isSafeToCreateProjectIn
 };


### PR DESCRIPTION
**Description**
`omi-cli` current empty a directory, if directory is not empty after confirm.
It is little dangerous so in this commit, it is changed as only notice to user there has invalid file/directory except some of verified file/directory: **.git** directory.

**What changed is**
AS-IS:
1. Verify target directory is empty, or not
2. Confirm to user to empty
3. Empty target directory
4. Create a project

TO-BE:
1. Verify target directory is empty, or not
2. Verify there only valid directory/file, or not (i.e. **.git**)
3. Remove 'npm-debug.log',  'yarn-error.log', 'yarn-debug.log'
4. Create a project

**In addition**
Normally, we clone git on our local, then create a project, but current version cannot create a project if there is **.git**  so there are two advantages: 1. safety, 2. improve user experience