### PR TITLE
Bugfix/omi cli valid project name

### DIFF
--- a/packages/omi-cli/lib/init.js
+++ b/packages/omi-cli/lib/init.js
@@ -13,6 +13,7 @@ var error = require("./logger").error;
 var success = require("./logger").success;
 var isCnFun = require("./utils").isCnFuc;
 var emptyFs = require("./utils").emptyFs;
+var checkAppName = require("./utils").checkAppName;
 var isSafeToCreateProjectIn = require("./utils").isSafeToCreateProjectIn;
 
 function init(args) {
@@ -30,6 +31,7 @@ function init(args) {
 		omiCli +
 			(!isCn ? " will execute init command... " : " 即将执行 init 命令...")
 	);
+	checkAppName(projectName);
 	if (existsSync(dest) && !emptyDir.sync(dest)) {
 		if (!isSafeToCreateProjectIn(dest, projectName)) {
 			process.exit(1);
@@ -63,7 +65,7 @@ function init(args) {
 					if (customPrjName) {
 						try {
 							var appPackage = require(join(dest,"package.json"));
-							appPackage.name = customPrjName;
+							appPackage.name = projectName;
 							fs.writeFile(join(dest,"package.json"), JSON.stringify(appPackage, null, 2), (err) => {
 								if (err) return console.log(err);
 							})

--- a/packages/omi-cli/lib/utils.js
+++ b/packages/omi-cli/lib/utils.js
@@ -6,6 +6,7 @@ var readdirSync = fs.readdirSync;
 var rmdirSync = fs.rmdirSync;
 var unlinkSync = fs.unlinkSync;
 var statSync = fs.statSync;
+var validateProjectName = require('validate-npm-package-name');
 
 function isCnFuc(language) {
 	return language === "cn" ? true : false;
@@ -102,8 +103,34 @@ function isSafeToCreateProjectIn(root, name) {
   return true;
 }
 
+// validate an app(project) name
+// - Nameing Rules: https://www.npmjs.com/package/validate-npm-package-name#naming-rules
+// - Referenced: https://github.com/facebook/create-react-app/blob/master/packages/create-react-app/createReactApp.js#L664
+function checkAppName(appName) {
+  const validationResult = validateProjectName(appName);
+  if (!validationResult.validForNewPackages) {
+    console.error(
+      `Could not create a project called ${chalk.red(
+        `"${appName}"`
+      )} because of npm naming restrictions: `
+    );
+    printValidationResults(validationResult.errors);
+    printValidationResults(validationResult.warnings);
+    process.exit(1);
+  }
+
+  function printValidationResults(results) {
+    if (typeof results !== 'undefined') {
+      results.forEach(error => {
+        console.error(chalk.red(`  *  ${error}`));
+      });
+    }
+  }
+}
+
 module.exports = {
 	isCnFuc: isCnFuc,
 	emptyFs: emptyFs,
-	isSafeToCreateProjectIn: isSafeToCreateProjectIn
+  isSafeToCreateProjectIn: isSafeToCreateProjectIn,
+  checkAppName: checkAppName
 };

--- a/packages/omi-cli/package.json
+++ b/packages/omi-cli/package.json
@@ -37,6 +37,7 @@
     "fs-exists-sync": "^0.1.0",
     "jsdom": "^9.12.0",
     "ora": "^1.1.0",
+    "validate-npm-package-name": "^3.0.0",
     "vinyl-fs": "^2.4.4",
     "webpack": "^2.3.3",
     "which": "^1.2.14"


### PR DESCRIPTION
**Description**
There has an error that **Cannot Run a Created Project** by `omi init .`, and omi-cli does not validate project name. Thus, I added a function to validate a project name same like `create-react-app` does.

**New Naming Rules**
https://www.npmjs.com/package/validate-npm-package-name#naming-rules

**Reference**
https://github.com/facebook/create-react-app/blob/master/packages/create-react-app/createReactApp.js#L664

**NOTE**
It is only added `omi init` because others does not replace a project name, i.e. `omi-ts init`

![omi_cli_underscore_project_name](https://user-images.githubusercontent.com/2471651/48668545-0345a700-eb44-11e8-896f-753bbcc56162.png)
