### PR TITLE
version omi-cli 3.0.19

### DIFF
--- a/packages/omi-cli/package.json
+++ b/packages/omi-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omi-cli",
-  "version": "3.0.18",
+  "version": "3.0.19",
   "description": "Create website with no build configuration. be friendly to [Omi](https://github.com/Tencent/omi) framework.",
   "main": "bin/omi",
   "engines": {


### PR DESCRIPTION
- update version number of **omi-cli** as **3.0.19**
  - removed `node_modules` in `templates/app`

The below commands are available from 3.0.18
- `omi init {project_name}`
- `omi-cli init {project_name}`
- `npx omi-cli init {project_name}`