### PR TITLE
omi-cli - init-template

### DIFF
--- a/packages/omi-cli/bin/omi
+++ b/packages/omi-cli/bin/omi
@@ -28,87 +28,87 @@ program
     .description('Initialize a new Omi application in the current folder')
     .action(function(projectName, option){
         var cmd = 'init';
-        if(option.parent.mirror && typeof option.parent.mirror === "string"){
+        if (option.parent.mirror && typeof option.parent.mirror === 'string') {
             options.mirror = option.parent.mirror;
         }
-        switchCommand(cmd, {project: projectName, mirror: options.mirror, language: options.language})
-    })
+        switchCommand(cmd, { project: projectName, mirror: options.mirror, language: options.language });
+    });
 
 program
     .command('init-spa [projectName]')
     .description('Initialize a new SPA with omi-router in the current folder')
     .action(function(projectName, option){
         var cmd = 'init-spa';
-        if(option.parent.mirror && typeof option.parent.mirror === "string"){
+        if (option.parent.mirror && typeof option.parent.mirror === 'string') {
             options.mirror = option.parent.mirror;
         }
-        switchCommand(cmd, {project: projectName, mirror: options.mirror, language: options.language})
-		})
+        switchCommand(cmd, { project: projectName, mirror: options.mirror, language: options.language });
+    })
 
 program
     .command('init-o [projectName]')
     .description('Initialize a new omio(IE8+) project in the current folder')
     .action(function(projectName, option){
         var cmd = 'init-o';
-        if(option.parent.mirror && typeof option.parent.mirror === "string"){
+        if (option.parent.mirror && typeof option.parent.mirror === 'string') {
             options.mirror = option.parent.mirror;
         }
-        switchCommand(cmd, {project: projectName, mirror: options.mirror, language: options.language})
-        })
+        switchCommand(cmd, { project: projectName, mirror: options.mirror, language: options.language });
+    });
 
 program
-        .command('init-weui [projectName]')
-        .description('Initialize a mobile project with weui in the current folder')
-        .action(function(projectName, option){
-            var cmd = 'init-o';
-            if(option.parent.mirror && typeof option.parent.mirror === "string"){
-                options.mirror = option.parent.mirror;
-            }
-            switchCommand(cmd, {project: projectName, mirror: options.mirror, language: options.language})
-            })
+    .command('init-weui [projectName]')
+    .description('Initialize a mobile project with weui in the current folder')
+    .action(function(projectName, option){
+        var cmd = 'init-o';
+        if (option.parent.mirror && typeof option.parent.mirror === 'string') {
+            options.mirror = option.parent.mirror;
+        }
+        switchCommand(cmd, { project: projectName, mirror: options.mirror, language: options.language });
+    });
 
 program
     .command('init-mvvm [projectName]')
     .description('Initialize a new MVVM project in the current folder')
     .action(function(projectName, option){
         var cmd = 'init-mvvm';
-        if(option.parent.mirror && typeof option.parent.mirror === "string"){
+        if(option.parent.mirror && typeof option.parent.mirror === 'string'){
             options.mirror = option.parent.mirror;
         }
-        switchCommand(cmd, {project: projectName, mirror: options.mirror, language: options.language})
-		})
+        switchCommand(cmd, { project: projectName, mirror: options.mirror, language: options.language });
+    });
 
 program
     .command('init-mp [projectName]')
     .description('Initialize a new omi-mp project in the current folder')
     .action(function(projectName, option){
         var cmd = 'init-mp';
-        if(option.parent.mirror && typeof option.parent.mirror === "string"){
+        if(option.parent.mirror && typeof option.parent.mirror === 'string'){
             options.mirror = option.parent.mirror;
         }
-        switchCommand(cmd, {project: projectName, mirror: options.mirror, language: options.language})
-		})
+        switchCommand(cmd, { project: projectName, mirror: options.mirror, language: options.language });
+    });
 
 program
     .command('init-md2site [projectName]')
     .description('Initialize a new omi-md2site project in the current folder')
     .action(function(projectName, option){
         var cmd = 'init-md2site';
-        if(option.parent.mirror && typeof option.parent.mirror === "string"){
+        if(option.parent.mirror && typeof option.parent.mirror === 'string'){
             options.mirror = option.parent.mirror;
         }
-        switchCommand(cmd, {project: projectName, mirror: options.mirror, language: options.language})
-    })
+        switchCommand(cmd, { project: projectName, mirror: options.mirror, language: options.language });
+    });
     
 program
     .command('init-ts [projectName]')
     .description('Initialize a new omi project with typescript in the current folder')
     .action(function(projectName, option){
         var cmd = 'init-ts';
-        if(option.parent.mirror && typeof option.parent.mirror === "string"){
+        if(option.parent.mirror && typeof option.parent.mirror === 'string'){
             options.mirror = option.parent.mirror;
         }
-        switchCommand(cmd, {project: projectName, mirror: options.mirror, language: options.language})
+        switchCommand(cmd, { project: projectName, mirror: options.mirror, language: options.language });
     })
 
 program
@@ -116,15 +116,29 @@ program
     .description('Compile your omi project')
     .action(function(option){
         var cmd = 'pr';
-        switchCommand(cmd, {language: options.language})
-    })
+        switchCommand(cmd, { language: options.language });
+    });
 
 
 program
     .command('*')
-    .action(function(){
-        spawn('omi', ['-h'], { stdio: 'inherit'})
-    })
+    .action(function(cmd){
+        const templateName = isInitTemplate(cmd); // verify init-{templateName}
+        const option = arguments[2] || arguments[1]; // if no arguments[2], second parameter is an option.
+        const projectName = typeof arguments[1] === 'string' ? arguments[1] : ''; // if arguments[1] is not a string, no project name input.
+        // init a template
+        if (templateName) {
+            var cmd = 'init-template';
+            if(option.parent.mirror && typeof option.parent.mirror === 'string'){
+                options.mirror = option.parent.mirror;
+            }
+            // omi init-{templateName} {projectName}
+            switchCommand(cmd, { project: projectName, template: templateName, mirror: options.mirror, language: options.language });
+        } else {
+            // default, if it is not init a template
+            spawn('omi', ['-h'], { stdio: 'inherit' })
+        }
+    });
 
 program.parse(process.argv);
 
@@ -136,16 +150,22 @@ function switchCommand (cmd, args) {
     }
 }
 
-function isCnFuc(language){
+function isCnFuc(language) {
     return language === "cn" ? true : false
 }
 
-function selectLanguage(language){
+function selectLanguage(language) {
     if(language !== 'en' && language !== 'cn'){
         language = 'en';
     }
     options.language = language;
     return language;
+}
+
+// verify a command is init a template, and return a template name without init-
+// i.e. init-omi-cli to omi-cli
+function isInitTemplate(cmd) {
+    return /init-(.)+/.test(cmd) && /init-([^\ ]+)/.exec(cmd)[1];
 }
 
 function executable(cmd) {
@@ -167,5 +187,3 @@ function help() {
     console.log();
     console.log('  All commands can be run with -h (or --help) for more information.')
 }
-
-

--- a/packages/omi-cli/lib/init-template.js
+++ b/packages/omi-cli/lib/init-template.js
@@ -1,0 +1,114 @@
+var path = require('path');
+var join = path.join;
+var basename = path.basename;
+var fs = require('fs');
+var existsSync = fs.existsSync;
+var chalk = require('chalk');
+var emptyDir = require('empty-dir');
+var info = require('./logger').info;
+var error = require('./logger').error;
+var success = require('./logger').success;
+var isCnFun = require('./utils').isCnFuc;
+var checkAppName = require('./utils').checkAppName;
+var isSafeToCreateProjectIn = require('./utils').isSafeToCreateProjectIn;
+var spawn = require('cross-spawn');
+
+function init(args) {
+	var omiCli = chalk.bold.cyan("Omi-Cli");
+	var isCn = isCnFun(args.language);
+  var customPrjName = args.project || '';
+  var templateName = args.template || '';
+	var dest = join(process.cwd(), customPrjName);
+	var projectName = basename(dest);
+  var mirror = args.mirror;
+  
+	console.log();
+	console.log(omiCli + (!isCn ? ' is booting... ' : ' 正在启动...'));
+	console.log(
+		omiCli +
+			(!isCn ? ' will execute init command... ' : ' 即将执行 init 命令...')
+	);
+	checkAppName(projectName);
+	if (existsSync(dest) && !emptyDir.sync(dest)) {
+		if (!isSafeToCreateProjectIn(dest, projectName)) {
+			process.exit(1);
+		}
+	}
+		
+	createApp();
+
+	function createApp() {
+		console.log();
+		console.log(
+			chalk.bold.cyan('Omi-Cli') +
+				(!isCn
+					? ' will creating a new omi app in '
+					: ' 即将创建一个新的应用在 ') +
+				dest
+    );
+    
+    console.log();
+
+    // git clone a template from https://www.github.com/omijs/template-{templateName}
+    const { status, error: cloneError }  = spawn.sync('git', ['clone', '--depth=1', `https://www.github.com/omijs/template-${templateName}`, customPrjName || '.']);
+
+    // verify git clone succeed
+    if (!cloneError && status === 0) {
+      try {
+          try {
+            // remove .git
+            const gitPath = join(dest, '.git');
+            if (existsSync(gitPath)) {
+              spawn.sync('rm', ['-rf', gitPath])
+            }
+
+            // change a package name as a project name if package.json exist
+            if (existsSync(join(dest, 'package.json'))) {
+              var appPackage = require(join(dest, 'package.json'));
+              appPackage.name = projectName;
+              fs.writeFile(join(dest, 'package.json'), JSON.stringify(appPackage, null, 2), (err) => {
+                if (err) return console.log(err);
+              });
+            }
+            process.chdir(customPrjName || '.');
+          } catch (e) {
+            console.log(error(e));
+          }
+        info(
+          'Install',
+          'We will install dependencies, if you refuse, press ctrl+c to abort, and install dependencies by yourself. :>'
+        );
+        console.log();
+        // install ndoe package modules
+        require('./install')(mirror, done);
+      } catch (e) {
+        console.log(error(e));
+      }
+    } else {
+      // if incorrect template name
+      error(`${templateName} is an ineixst template.
+Please check on https://github.com/omijs
+`);
+    }
+	}
+
+  // NOTE - to edit as template paragraph.
+	function done() {
+		console.log();
+		console.log();
+		console.log();
+		success(`Congratulation! "${projectName}" has been created successful! `);
+		console.log(`
+
+Using the scaffold with Gulp + Webpack + Babel + BrowserSync,
+
+if you are not in ${projectName}, please run 'cd ${projectName}', then you can:
+
+    > ${chalk.bold.white("npm run dev")}         Starts the development server
+    > ${chalk.bold.white("npm run dist")}        Publish your project`);
+		console.log();
+		console.log(`${chalk.bold.cyan("Omi!")} https://alloyteam.github.io/omi`);
+	}
+}
+
+module.exports = init;

--- a/packages/omi-cli/package.json
+++ b/packages/omi-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omi-cli",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "Create website with no build configuration. be friendly to [Omi](https://github.com/Tencent/omi) framework.",
   "main": "bin/omi",
   "engines": {


### PR DESCRIPTION
**Description**
There have many templates more and more so omi-cli size is being little heavy.
Thus, we decided to separate between **omi-cli** and **templates** from now, and new template will be stored on https://github.com/omijs with `template-` prefix. i.e **[template-ts](https://github.com/omijs/template-ts)**

How it creates a template, it does `git clone https://www.github.com/omijs/ts-{templateName}`.

**What added**
- add a new spec **omi-cli init-{templateName}**
``` bash
> omi-cli init-{templateName} {projectName}
> omi-cli init-cli-test myProject
```
- changed /packages/omi-cli/bin/omi
- added /packages/omi-cli/lib/init-template.js
- changed a version of omi-cli as **3.1.4**
[**NOTE**]If it is fine, we need to publish it @dntzhang 

**How to TEST**
I have already tested by my self with `omi-cli-test@3.1.3`

```
> npm i -g omi-cli-test@3.1.3
> omi-cli-test init-cli-test ./myApp
```
