### PR TITLE
omi-cli: not install npm if no package.json

### DIFF
--- a/packages/omi-cli/lib/init-template.js
+++ b/packages/omi-cli/lib/init-template.js
@@ -69,18 +69,20 @@ function init(args) {
               fs.writeFile(join(dest, 'package.json'), JSON.stringify(appPackage, null, 2), (err) => {
                 if (err) return console.log(err);
               });
+
+              process.chdir(customPrjName || '.');
+
+              // install ndoe package modules
+              info(
+                'Install',
+                'We will install dependencies, if you refuse, press ctrl+c to abort, and install dependencies by yourself. :>'
+              );
+              console.log();
+              require('./install')(mirror, done); // npm install
             }
-            process.chdir(customPrjName || '.');
           } catch (e) {
             console.log(error(e));
           }
-        info(
-          'Install',
-          'We will install dependencies, if you refuse, press ctrl+c to abort, and install dependencies by yourself. :>'
-        );
-        console.log();
-        // install ndoe package modules
-        require('./install')(mirror, done);
       } catch (e) {
         console.log(error(e));
       }

--- a/packages/omi-cli/package.json
+++ b/packages/omi-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omi-cli",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Create website, app with no build configuration. be friendly to [Omi](https://github.com/Tencent/omi) framework.",
   "main": "bin/omi",
   "engines": {


### PR DESCRIPTION
**Description**
`omi-cli` template is execute npm install even though no package.json. 
This PR is disable ```npm install``` if no package.json

- fix not install npm if no package.json
- version up `omi-cli` as **3.2.2** from 3.2.1

**How to Test**
```bash
> npm i -g omi-cli-test@3.1.4
> omi-cli-test init-cli-test myPro
> cd myPro
```
verify there is **node_modules** or not

@dntzhang Please ```npm publish```, if you fine with it.
