### PR TITLE
add applyRef/createRef in omio

### DIFF
--- a/packages/omio/src/dom/index.js
+++ b/packages/omio/src/dom/index.js
@@ -1,5 +1,5 @@
 import { IS_NON_DIMENSIONAL } from '../constants'
-import { applyRef } from '../utils'
+import { applyRef } from '../util'
 import options from '../options'
 
 /** Create an element with the given nodeName.

--- a/packages/omio/src/dom/index.js
+++ b/packages/omio/src/dom/index.js
@@ -1,4 +1,5 @@
 import { IS_NON_DIMENSIONAL } from '../constants'
+import { applyRef } from '../utils'
 import options from '../options'
 
 /** Create an element with the given nodeName.
@@ -49,8 +50,8 @@ export function setAccessor(node, name, old, value, isSvg) {
   if (name === 'key') {
     // ignore
   } else if (name === 'ref') {
-    if (old) old(null)
-    if (value) value(node)
+    applyRef(old, null)
+    applyRef(value, node)
   } else if (name === 'class' && !isSvg) {
     node.className = value || ''
   } else if (name === 'style') {

--- a/packages/omio/src/omi.js
+++ b/packages/omio/src/omi.js
@@ -11,11 +11,13 @@ import { classNames, extractClass } from './class'
 
 const WeElement = Component
 const defineElement = define
+const createRef = Object
 
 options.root.Omi = {
   h,
   createElement,
   cloneElement,
+  createRef,
   Component,
   render,
   rerender,
@@ -35,6 +37,7 @@ export default {
   h,
   createElement,
   cloneElement,
+  createRef,
   Component,
   render,
   rerender,
@@ -52,6 +55,7 @@ export {
   h,
   createElement,
   cloneElement,
+  createRef,
   Component,
   render,
   rerender,

--- a/packages/omio/src/util.js
+++ b/packages/omio/src/util.js
@@ -129,6 +129,17 @@ export function extend(obj, props) {
   return obj
 }
 
+/** Invoke or update a ref, depending on whether it is a function or object ref.
+ *  @param {object|function} [ref=null]
+ *  @param {any} [value]
+ */
+export function applyRef(ref, value) {
+  if (ref) {
+    if (typeof ref == 'function') ref(value)
+    else ref.current = value
+  }
+}
+
 /**
  * Call a function asynchronously, as soon as possible. Makes
  * use of HTML Promise to schedule the callback if available,

--- a/packages/omio/src/vdom/component.js
+++ b/packages/omio/src/vdom/component.js
@@ -6,7 +6,7 @@ import {
   ATTR_KEY
 } from '../constants'
 import options from '../options'
-import { extend } from '../util'
+import { extend, applyRef } from '../util'
 import { enqueueRender } from '../render-queue'
 import { getNodeProps } from './index'
 import {
@@ -48,7 +48,7 @@ export function setComponentProps(component, props, opts, context, mountAll) {
     }
   } else if (component.receiveProps) {
     component.receiveProps(props, component.data, component.props)
-  } 
+  }
 
   if (context && context !== component.context) {
     if (!component.prevContext) component.prevContext = component.context
@@ -72,7 +72,7 @@ export function setComponentProps(component, props, opts, context, mountAll) {
     }
   }
 
-  if (component.__ref) component.__ref(component)
+  applyRef(component.__ref, component)
 }
 
 function shallowComparison(old, attrs) {
@@ -255,7 +255,6 @@ export function renderComponent(component, opts, mountAll, isChild) {
     // Note: disabled as it causes duplicate hooks, see https://github.com/developit/preact/issues/750
     // flushMounts();
 
-   
     if (component.afterUpdate) {
       //deprecated
       component.afterUpdate(previousProps, previousState, previousContext)
@@ -338,7 +337,7 @@ export function unmountComponent(component) {
   if (inner) {
     unmountComponent(inner)
   } else if (base) {
-    if (base[ATTR_KEY] && base[ATTR_KEY].ref) base[ATTR_KEY].ref(null)
+    if (base[ATTR_KEY] != null) applyRef(base[ATTR_KEY].ref, null)
 
     component.nextBase = base
 
@@ -348,5 +347,5 @@ export function unmountComponent(component) {
     removeChildren(base)
   }
 
-  if (component.__ref) component.__ref(null)
+  applyRef(component.__ref, null)
 }

--- a/packages/omio/src/vdom/diff.js
+++ b/packages/omio/src/vdom/diff.js
@@ -4,6 +4,7 @@ import { buildComponentFromVNode } from './component'
 import { createNode, setAccessor } from '../dom/index'
 import { unmountComponent } from './component'
 import options from '../options'
+import { applyRef } from '../util'
 import { removeNode } from '../dom/index'
 import { isArray } from '../util'
 
@@ -300,7 +301,7 @@ export function recollectNodeTree(node, unmountOnly) {
   } else {
     // If the node's VNode had a ref function, invoke it with null here.
     // (this is part of the React spec, and smart for unsetting references)
-    if (node[ATTR_KEY] != null && node[ATTR_KEY].ref) node[ATTR_KEY].ref(null)
+    if (node[ATTR_KEY] != null) applyRef(node[ATTR_KEY].ref, null)
 
     if (unmountOnly === false || node[ATTR_KEY] == null) {
       removeNode(node)

--- a/packages/omio/test/browser/util.js
+++ b/packages/omio/test/browser/util.js
@@ -1,0 +1,27 @@
+import { applyRef } from '../../src/util'
+
+describe('applyRef()', () => {
+  it('should be called a ref function', () => {
+    const ref = () => {}
+    const cb = sinon.spy(ref)
+    applyRef(cb)
+    expect(cb).to.have.been.called
+  })
+
+  it('should be called a ref function with value argument', () => {
+    const ref = () => {}
+    const cb = sinon.spy(ref)
+    const value = 'omi'
+    applyRef(cb, value)
+    expect(cb).to.have.been.calledWithMatch(value)
+  })
+
+  it('should be assigned a value to current property', () => {
+    const ref = {
+      current: ''
+    }
+    const value = 'omi'
+    applyRef(ref, value)
+    expect(ref.current).to.equal('omi')
+  })
+})


### PR DESCRIPTION
**Description**
`ref={e=>{}}` has a performance issue, and **preact** resolved the issue with new function **applyRef**.

**Changed**
Changed as using **applyRef** function same as **preact**
(REF: https://github.com/developit/preact/commit/f634d122dab064a34bad5dda83e36b50a8a7c488)

@dntzhang In this PR, I only added a test code for **applyRef**.
(https://github.com/Tencent/omi/compare/master...LeeHyungGeun:feature/createRef?expand=1#diff-927127f97d85209953b87a0a14e0cbc4R1)