### PR TITLE
change createRef as a function from object

### DIFF
--- a/packages/omio/src/omi.js
+++ b/packages/omio/src/omi.js
@@ -11,7 +11,9 @@ import { classNames, extractClass } from './class'
 
 const WeElement = Component
 const defineElement = define
-const createRef = Object
+function createRef() {
+  return {}
+}
 
 options.root.Omi = {
   h,


### PR DESCRIPTION
**Description**
`createRef` is now an object. preact already changed it as a function and it will return new everytime.

**Changed**
createdRef
- as-is: Object
- to-be: Function