### PR TITLE
Fix gitignore rename bug in app-ts(init ts)

### DIFF
--- a/packages/omi-cli/lib/init-ts.js
+++ b/packages/omi-cli/lib/init-ts.js
@@ -58,8 +58,12 @@ function init(args) {
 			.pipe(vfs.dest(dest))
 			.on("end", function() {
 				try {
-					info("Rename", "gitignore -> .gitignore");
-					renameSync(join(dest, "gitignore"), join(dest, ".gitignore"));
+					// rename gitignore file as .gitignore if `gitignore` exist
+					// (this was actually exist in app-ts-old)
+					if (existsSync(join(dest, "gitignore"))) {
+						info("Rename", "gitignore -> .gitignore");
+						renameSync(join(dest, "gitignore"), join(dest, ".gitignore"));
+					}
 					if (customPrjName) {
 						try {
 							process.chdir(customPrjName);


### PR DESCRIPTION
**Description**
Since `gitignore` in `app-ts` template(`gitignore` is only exist in `app-ts-old`) changed as `.gitignore`, but it is still trying to rename so it occurs an error.
![init-ts_gitignore](https://user-images.githubusercontent.com/2471651/52351476-cfed2700-2a65-11e9-8752-ff50fe4bd9d4.png)

**Changed**
- check `gitignore` file exist, and rename if exist.