### PR TITLE
Add class back

### DIFF
--- a/packages/omi-cli/template/app/src/elements/app-omil/index.omi
+++ b/packages/omi-cli/template/app/src/elements/app-omil/index.omi
@@ -7,7 +7,7 @@
 // Recommend install omi-snippets plugins in VSC
 // Omi-snippets: https://marketplace.visualstudio.com/items?itemName=Wscats.omi-snippets
 import style from './_index.css'
-export default {
+export default class {
   static css = style + `
     button{
       background-color: #58bc58;


### PR DESCRIPTION
It's grammatical to have or not have 'class'. But I still recommend 'class'. So I add it back.