### PR TITLE
fix(omix):solve recurring '$' in _update

### DIFF
--- a/packages/omix/utils/create.js
+++ b/packages/omix/utils/create.js
@@ -128,8 +128,10 @@ function _update(kv, store) {
       if (store.updateAll || ins.__updatePath && needUpdate(kv, ins.__updatePath)) {
         if (ins.__hasData) {
           for (let pk in kv) {
-            kv['$.' + pk] = kv[pk]
-            delete kv[pk]
+            if (!/\$./.test(pk)) {
+              kv['$.' + pk] = kv[pk]
+              delete kv[pk]
+            }
           }
           ins.setData.call(ins, kv)
         } else {


### PR DESCRIPTION
**bug**：多页面使用store，且在store更新时会对挂载在data上的$（'store数据'）会产生以下问题：
多次给$追加$，导致更新视图失败。
```javascript
// 两个页面更新store时产生如下
$.user
$.$.user
```
该提交是为了解决该问题，已通过测试