### PR TITLE
fix(omiv): 修复 Ctor.options 没有被 $ 包裹 vm 依赖没有被 store 收集的问题

### DIFF
--- a/packages/omiv/examples/multiple-stores/src/App.vue
+++ b/packages/omiv/examples/multiple-stores/src/App.vue
@@ -1,20 +1,20 @@
 <template>
   <div id="app">
-    <img alt="Vue logo" src="./assets/logo.png" />
+    <img alt="Vue logo"
+      src="./assets/logo.png" />
     <HelloWorld msg="Welcome to Your Vue + Omiv App" />
   </div>
 </template>
 
 <script>
-import { $ } from 'omiv'
 import HelloWorld from './components/HelloWorld.vue'
 
-export default $({
+export default {
   name: 'app',
   components: {
     HelloWorld
   }
-})
+}
 </script>
 
 <style>

--- a/packages/omiv/examples/multiple-stores/src/components/HelloWorld.vue
+++ b/packages/omiv/examples/multiple-stores/src/components/HelloWorld.vue
@@ -5,14 +5,12 @@
     <span>{{state.cs.count}}</span>
     <button @click="store.cs.add">+</button>
     <div>double: {{store.cs.getDoubleCount()}}</div>
-		<span>{{state.ns.name}}</span>
+    <span>{{state.ns.name}}</span>
   </div>
 </template>
 
 <script>
-import { $ } from 'omiv'
-
-export default $({
+export default {
   name: 'HelloWorld',
   props: {
     msg: String
@@ -20,7 +18,7 @@ export default $({
   useSelf: {
     cs: ['count']
   }
-})
+}
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->

--- a/packages/omiv/examples/multiple-stores/src/main.js
+++ b/packages/omiv/examples/multiple-stores/src/main.js
@@ -1,10 +1,11 @@
 import Vue from 'vue'
 import App from './App.vue'
-import { render } from 'omiv'
+import Omiv, { render } from '../../../src/omiv'
+
+Vue.use(Omiv)
 Vue.config.productionTip = false
 
-
-const cs = new class {
+const cs = new (class {
   data = {
     count: 1
   }
@@ -18,18 +19,15 @@ const cs = new class {
   getDoubleCount = () => {
     return this.data.count * 2
   }
-}
+})()
 
-const ns = new class {
+const ns = new (class {
   data = {
     name: 'omiv'
   }
   rename = () => {
     this.data.name = 'omiv + vue'
   }
-}
+})()
 
 render(App, '#app', { cs, ns })
-
-
-

--- a/packages/omiv/examples/simple/src/App.vue
+++ b/packages/omiv/examples/simple/src/App.vue
@@ -6,15 +6,14 @@
 </template>
 
 <script>
-import { $ } from 'omiv'
 import HelloWorld from './components/HelloWorld.vue'
 
-export default $({
+export default {
   name: 'app',
   components: {
     HelloWorld
   }
-})
+}
 </script>
 
 <style>

--- a/packages/omiv/examples/simple/src/components/HelloWorld.vue
+++ b/packages/omiv/examples/simple/src/components/HelloWorld.vue
@@ -4,20 +4,18 @@
     <button @click="store.sub">-</button>
     <span>{{state.count}}</span>
     <button @click="store.add">+</button>
-		<div>double: {{store.getDoubleCount()}}</div>
+    <div>double: {{store.getDoubleCount()}}</div>
   </div>
 </template>
 
 <script>
-import { $ } from 'omiv'
-
-export default $({
+export default {
   name: 'HelloWorld',
   props: {
     msg: String
   },
   useSelf: ['count']
-})
+}
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->

--- a/packages/omiv/examples/simple/src/main.js
+++ b/packages/omiv/examples/simple/src/main.js
@@ -1,25 +1,26 @@
 import Vue from 'vue'
 import App from './App.vue'
-import { render } from 'omiv'
+import Omiv, { render } from '../../../src/omiv'
+
+Vue.use(Omiv)
 Vue.config.productionTip = false
 
+render(
+  App,
+  '#app',
+  new (class {
+    data = {
+      count: 1
+    }
+    sub = () => {
+      this.data.count--
+    }
+    add = () => {
+      this.data.count++
+    }
 
-
-render(App, '#app', new class {
-  data = {
-    count: 1
-  }
-  sub = () => {
-    this.data.count--
-  }
-  add = () => {
-    this.data.count++
-  }
-
-  getDoubleCount = () => {
-    return this.data.count * 2
-  }
-})
-
-
-
+    getDoubleCount = () => {
+      return this.data.count * 2
+    }
+  })()
+)

--- a/packages/omiv/test/browser/components/child3.vue
+++ b/packages/omiv/test/browser/components/child3.vue
@@ -1,0 +1,12 @@
+<template>
+  <div id='app'>
+    <span class="count">{{ state.count }}</span>
+    <button @click="$store.add">Increment</button>
+  </div>
+</template>
+
+<script>
+export default {
+  useSelf: ['count']
+}
+</script>

--- a/packages/omiv/test/browser/index.js
+++ b/packages/omiv/test/browser/index.js
@@ -7,14 +7,14 @@ import Omiv, { render } from '../../src/omiv'
 //import Nest from './components/nest.vue'
 
 const errorHandler = (error, vm) => {
-  console.error('--------------------------------------------------------------------')
+  console.error(
+    '--------------------------------------------------------------------'
+  )
   throw error
-
 }
 
-
-Vue.config.errorHandler = errorHandler;
-Vue.prototype.$throw = (error) => errorHandler(error, this);
+Vue.config.errorHandler = errorHandler
+Vue.prototype.$throw = error => errorHandler(error, this)
 
 describe('base', () => {
   let scratch
@@ -178,7 +178,7 @@ describe('base', () => {
     })
   })
 
-  it('mixin $store test', (done) => {
+  it('mixin $store test use', done => {
     const cs = new (class {
       data = {
         count: 2
@@ -191,6 +191,30 @@ describe('base', () => {
       }
     })()
     render(require('./components/child2.vue').default, '#app', cs)
+
+    document.querySelector('button').click()
+
+    Vue.nextTick(() => {
+      done()
+      expect(document.querySelector('#app').innerHTML).to.equal(
+        '<span class="count">3</span> <button>Increment</button>'
+      )
+    })
+  })
+
+  it('mixin $store test useSelf', done => {
+    const cs = new (class {
+      data = {
+        count: 2
+      }
+      sub = () => {
+        this.data.count--
+      }
+      add = () => {
+        this.data.count++
+      }
+    })()
+    render(require('./components/child3.vue').default, '#app', cs)
 
     document.querySelector('button').click()
 


### PR DESCRIPTION
1. 更新了 child2 和 child3 test , $ 不需要再手动调用，但是 use 或者 useSelf 是需要的，主要还是通过这两个字段来收集依赖
2. examples 中的两个 demo， omiv 路径换成 src/omiv ， 便于本地调试