### PR TITLE
rename internal var to avoid collision - omix

### DIFF
--- a/packages/omix/README.md
+++ b/packages/omix/README.md
@@ -173,7 +173,7 @@ this.store.data.arr.push(111) //会触发视图更新
 this.store.data.arr.purePush(111) //不会触发视图更新
 
 this.store.set(this.store.data, 'newProp', 'newPropVal')  //会触发视图更新
-this.store.data.newProp = 'newPropVal' //新增属性不会触发视图更新，必须使用 create.set
+this.store.data.newProp = 'newPropVal' //新增属性不会触发视图更新，必须使用 store.set
 ```
 
 ###  计算属性


### PR DESCRIPTION
1. README 的一处，应该是 typo...吧
2. 重命名了内部使用的 buffer 和 tick lock，避免命名冲突
3. 将对 buffer 的前置创建改成了使用时 check，减少漏掉创建的可能（之前普通组件就会漏掉，没仔细看 _omixComponents）
4. 由于引入了 tick 聚合，可以在 replace store.data 的时候直接报错（比整个 break 掉要好），并提示应该 assign prop（因为 observe store.data 本身这个事情其实是为 omix 服务的，就还是实现在 omix 里了，不改 obaa）