### PR TITLE
replace slave label with replica

### DIFF
--- a/packages/omi/examples/perfs/env.js
+++ b/packages/omi/examples/perfs/env.js
@@ -138,14 +138,14 @@ var ENV = ENV || (function() {
       data = [];
       for (var i = 1; i <= ENV.rows; i++) {
         data.push({ dbname: 'cluster' + i, query: "", formatElapsed: "", elapsedClassName: "" });
-        data.push({ dbname: 'cluster' + i + ' slave', query: "", formatElapsed: "", elapsedClassName: "" });
+        data.push({ dbname: 'cluster' + i + ' replica', query: "", formatElapsed: "", elapsedClassName: "" });
       }
     }
     if (!data) { // first init when keepIdentity
       data = [];
       for (var i = 1; i <= ENV.rows; i++) {
         data.push({ dbname: 'cluster' + i });
-        data.push({ dbname: 'cluster' + i + ' slave' });
+        data.push({ dbname: 'cluster' + i + ' replica' });
       }
       oldData = data;
     }


### PR DESCRIPTION
Please consider this pull request. It replaces the antiquated word "slave" with the modern "replica". The example still works perfectly fine, I've tested it.