### PR TITLE
feat(table): add table body cell span 

### DIFF
--- a/components/table/src/demo.tsx
+++ b/components/table/src/demo.tsx
@@ -209,6 +209,24 @@ export default class TableDemo extends WeElement {
     }
   }]
 
+  cellSpanOption = {
+    bodyCellSpan: function({row, column}) {
+      if (row.id === 2) {
+        if (column.title === 'Name') {
+          return {
+            colspan: 2,
+            rowspan: 1,
+          }
+        } else if (column.title === 'Age'){
+          return {
+            colspan: 0,
+            rowspan: 0,
+          }
+        }
+      } 
+    } 
+  }
+
   onEditClick = (evt: Event) => {
 
   }
@@ -289,6 +307,7 @@ export default class TableDemo extends WeElement {
         fixedTop={this.fixedTop}
         columns={this.columns}
         dataSource={this.dataSource}
+        cellSpanOption={this.cellSpanOption}
       >
       </o-table>
     </div>

--- a/components/table/src/demo.tsx
+++ b/components/table/src/demo.tsx
@@ -211,7 +211,7 @@ export default class TableDemo extends WeElement {
 
   cellSpanOption = {
     bodyCellSpan: function({row, column}) {
-      if (row.id === 2) {
+      if (row.id === 8) {
         if (column.title === 'Name') {
           return {
             colspan: 2,
@@ -224,7 +224,22 @@ export default class TableDemo extends WeElement {
           }
         }
       } 
-    } 
+
+      if (column.title === 'Name') {
+        if (row.id === 13238) {
+          return {
+            colspan: 1,
+            rowspan: 3
+          }
+        } else if (row.id === 218|| row.id === 2113) {
+          return {
+            colspan: 0,
+            rowspan: 0
+          }
+        }
+      }
+    }
+    
   }
 
   onEditClick = (evt: Event) => {


### PR DESCRIPTION
根据 #744 ，OMIU Table 添加合并单元格功能。


![](https://s2.loli.net/2022/08/18/cPvVwmnKUZeq3R5.png)

使用：

+ 通过 props `cellSpanOption` 设置合并单元格，`cellSpanOption` 中通过方法 `bodyCellSpan({row, column})` 设置 `body` 单元格的合并。
+ 在 `bodyCellSpan({row, column})` 中通过 `row` 和 `column` 定位相应的单元格，返回 `colspan` 和 `rowspan` 属性指定合并的行数；同时需要指定不渲染的单元格，设置 `colspan` 和 `rowspan` 为 0 并返回即可。

存在问题和后续想法：

+ 排序后，合并 body 列可能出现位置错乱，这是因为合并单元格时指定单元格是通过单元格的位置而不是根据内容进行合并，还在思考更好的解决方法；
+ 还需要实现表格的头部和脚部的合并单元格功能、添加自定义合并单元格后渲染的内容。
