### PR TITLE
修复 site 使用的tsconfig 在 组件中无法使用的问题

### DIFF
--- a/tdesign/desktop/src/button/tsconfig.json
+++ b/tdesign/desktop/src/button/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.omi"
+}

--- a/tdesign/desktop/tsconfig.omi.json
+++ b/tdesign/desktop/tsconfig.omi.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "lib": [
+      "es2017",
+      "dom",
+      "dom.iterable"
+    ],
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "./types",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "experimentalDecorators": true,
+    "forceConsistentCasingInFileNames": true,
+    "jsx": "react",
+    "jsxFactory": "h",
+    "target": "es5",
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx"
+  ],
+  "exclude": []
+}


### PR DESCRIPTION
1. 今天遇到有人咨询，为什么跑组件的时候无法变异 jsx ，后来发现 因为root的tsconfig.json 使用了preserver  需要添加一个公共的 omi.json 进行管理jsx 编译 