### PR TITLE
feat: add rate

### DIFF
--- a/tdesign/desktop/src/rate/_example/base.tsx
+++ b/tdesign/desktop/src/rate/_example/base.tsx
@@ -1,0 +1,10 @@
+import { h, tag, WeElement } from 'omi'
+
+import '../index'
+
+@tag('rate-base')
+export default class RateBase extends WeElement {
+  render() {
+    return <t-rate default-value={3}></t-rate>
+  }
+}

--- a/tdesign/desktop/src/rate/_example/custom.tsx
+++ b/tdesign/desktop/src/rate/_example/custom.tsx
@@ -1,0 +1,10 @@
+import { h, tag, WeElement } from 'omi'
+
+import '../index'
+
+@tag('rate-custom')
+export default class RateCustom extends WeElement {
+  render() {
+    return <t-rate count={7} default-value={6}></t-rate>
+  }
+}

--- a/tdesign/desktop/src/rate/_example/status.tsx
+++ b/tdesign/desktop/src/rate/_example/status.tsx
@@ -1,0 +1,20 @@
+import { h, tag, WeElement } from 'omi'
+
+import '../index'
+import '../../space/index'
+
+@tag('rate-status')
+export default class RateStatus extends WeElement {
+  render() {
+    return (
+      <t-space direction="vertical" style={{ textAlign: 'center' }}>
+        <h3>未评分状态</h3>
+        <t-rate></t-rate>
+        <h3>满分状态</h3>
+        <t-rate default-value={5}></t-rate>
+        <h3>半星状态</h3>
+        <t-rate allow-half="true" default-value={4.5}></t-rate>
+      </t-space>
+    )
+  }
+}

--- a/tdesign/desktop/src/rate/index.html
+++ b/tdesign/desktop/src/rate/index.html
@@ -1,0 +1,11 @@
+<html>
+  <script type="module" src="./_example/base.tsx"></script>
+  <script type="module" src="./_example/custom.tsx"></script>
+  <script type="module" src="./_example/status.tsx"></script>
+  <script type="module" src="./index.tsx"></script>
+</html>
+<body>
+  <rate-base></rate-base>
+  <rate-custom></rate-custom>
+  <rate-status></rate-status>
+</body>

--- a/tdesign/desktop/src/rate/index.tsx
+++ b/tdesign/desktop/src/rate/index.tsx
@@ -1,0 +1,9 @@
+import _Rate from './rate'
+
+import './style/index.ts'
+
+export type { RateProps } from './type'
+export * from './type'
+
+export const Rate = _Rate
+export default Rate

--- a/tdesign/desktop/src/rate/rate.tsx
+++ b/tdesign/desktop/src/rate/rate.tsx
@@ -1,0 +1,135 @@
+import { h, tag, WeElement, OmiProps, define, classNames, createRef } from 'omi'
+import { RateProps } from './type'
+
+import css from './style/index'
+type IconProps = {
+  size: string
+  color: string
+}
+define(
+  'rate-icon',
+  class extends WeElement<IconProps> {
+    static css = css
+
+    render(props: OmiProps<IconProps>) {
+      return (
+        <svg
+          fill="none"
+          viewBox={`0 0 24 24`}
+          width="1em"
+          height="1em"
+          color="var(--td-bg-color-component)"
+          style={`font-size: ${props.size};`}
+        >
+          <path
+            fill={props.color}
+            d="M12 .63l2.9 8.35 8.84.18-7.04 5.34 2.56 8.46L12 17.91l-7.26 5.05L7.3 14.5.26 9.16l8.84-.18L12 .63z"
+          ></path>
+        </svg>
+      )
+    }
+  },
+)
+
+@tag('t-rate')
+export default class Rate extends WeElement<RateProps> {
+  static css = css as string
+
+  static defaultProps = {
+    defaultValue: 1,
+    allowHalf: false,
+    color: '#ED7B2F',
+    size: '24px',
+    count: 5,
+    gap: 4,
+    showText: false,
+    texts: ['极差', '失望', '一般', '满意', '惊喜'],
+  }
+
+  static propTypes = {
+    allowHalf: Boolean,
+    // color: Array,
+    count: Number,
+    disabled: Boolean,
+    gap: Number,
+    icon: Object,
+    showText: Boolean,
+    size: String,
+    texts: Array,
+    value: Number,
+    defaultValue: Number,
+    onChange: Function,
+  }
+
+  hoverValue: number | undefined = undefined
+  starValue: number | undefined = undefined
+  rootRef = createRef()
+  getStarValue = (event: MouseEvent, index: number) => {
+    if (this.props.allowHalf) {
+      const rootNode = this.rootRef.current
+      const { left } = rootNode.getBoundingClientRect()
+      const firstStar = rootNode.firstChild as HTMLElement
+      const { width } = firstStar.getBoundingClientRect()
+      const { clientX } = event
+      const starMiddle = width * (index - 0.5) + this.props.gap * (index - 1)
+      if (clientX - left >= starMiddle) return index
+      if (clientX - left < starMiddle) return index - 0.5
+    }
+    return index
+  }
+
+  mouseLeaveHandler = () => {
+    if (this.props.disabled) return
+    this.hoverValue = undefined
+    this.update()
+  }
+
+  mouseEnterHandler = (event: MouseEvent, index: number) => {
+    if (this.props.disabled) return
+    this.hoverValue = this.getStarValue(event, index)
+    this.update()
+  }
+
+  clickHandler = (event: MouseEvent, index: number) => {
+    if (this.props.disabled) return
+    this.starValue = this.getStarValue(event, index)
+    this.update()
+  }
+
+  render(props: OmiProps<RateProps>) {
+    const classPrefix = 't'
+    const displayValue = this.hoverValue || this.starValue || props.defaultValue
+    const activeColor = Array.isArray(this.props.color) ? this.props.color[0] : this.props.color
+    const defaultColor = Array.isArray(this.props.color) ? this.props.color[1] : 'var(--td-bg-color-component)'
+
+    const getStarCls = (index: number) => {
+      if (props.allowHalf && index + 0.5 === displayValue) return `${classPrefix}-rate__item--half`
+      if (index >= displayValue) return ''
+      if (index < displayValue) return `${classPrefix}-rate__item--full`
+    }
+    return (
+      <div class={`${classPrefix}-rate`} onMouseleave={this.mouseLeaveHandler}>
+        <ul class={`${classPrefix}-rate__list`} style={{ gap: `${props.gap}px` }} ref={this.rootRef}>
+          {[...Array(props.count)].map((_, index) => (
+            <li
+              key={index}
+              className={classNames(`${classPrefix}-rate__item`, getStarCls(index))}
+              onClick={(event) => this.clickHandler(event, index + 1)}
+              onMouseMove={(event) => this.mouseEnterHandler(event, index + 1)}
+            >
+              <>
+                <div className={`${classPrefix}-rate__star-top`}>
+                  <rate-icon size={props.size} color={activeColor} />
+                </div>
+                <div className={`${classPrefix}-rate__star-bottom`}>
+                  <rate-icon size={props.size} color={defaultColor} />
+                </div>
+              </>
+            </li>
+          ))}
+        </ul>
+        {props.showText && <div className={`${classPrefix}-rate__text`}>{props.texts[displayValue - 1]}</div>}
+      </div>
+    )
+  }
+}

--- a/tdesign/desktop/src/rate/style/index.ts
+++ b/tdesign/desktop/src/rate/style/index.ts
@@ -1,0 +1,3 @@
+import rateStyle from '../../_common/style/web/components/rate/_index.less'
+import theme from '../../_common/style/web/theme/_index.less'
+export default rateStyle + theme

--- a/tdesign/desktop/src/rate/type.ts
+++ b/tdesign/desktop/src/rate/type.ts
@@ -1,0 +1,62 @@
+import { TElement } from '../common'
+
+export interface RateProps {
+  /**
+   * 是否允许半选
+   * @default false
+   */
+  allowHalf?: boolean
+  /**
+   * 评分图标的颜色，样式中默认为 #ED7B2F。一个值表示设置选中高亮的五角星颜色，示例：[选中颜色]。数组则表示分别设置 选中高亮的五角星颜色 和 未选中暗灰的五角星颜色，[选中颜色，未选中颜色]。示例：['#ED7B2F', '#E3E6EB']
+   * @default '#ED7B2F'
+   */
+  color?: string | Array<string>
+  /**
+   * 评分的数量
+   * @default 5
+   */
+  count?: number
+  /**
+   * 是否禁用评分
+   * @default false
+   */
+  disabled?: boolean
+  /**
+   * 评分图标的间距
+   * @default 4
+   */
+  gap?: number
+  /**
+   * 自定义评分图标
+   */
+  icon?: TElement
+  /**
+   * 是否显示对应的辅助文字
+   * @default false
+   */
+  showText?: boolean
+  /**
+   * 评分图标的大小，示例：`20`
+   * @default ''
+   */
+  size?: string
+  /**
+   * 评分等级对应的辅助文字。组件内置默认值为：['极差', '失望', '一般', '满意', '惊喜']。自定义值示例：['1分', '2分', '3分', '4分', '5分']
+   * @default []
+   */
+  texts?: Array<string>
+  /**
+   * 选择评分的值
+   * @default 0
+   */
+  value?: number
+  /**
+   * 选择评分的值，非受控属性
+   * @default 0
+   */
+  defaultValue?: number
+  /**
+   * 评分数改变时触发
+   */
+  onChange?: (value: number) => void
+}

--- a/tdesign/desktop/src/rate/vite.config.js
+++ b/tdesign/desktop/src/rate/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite'
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  esbuild: {
+    jsxFactory: 'h',
+    jsxFragment: 'h.f',
+  },
+})


### PR DESCRIPTION
初步完成rate组件
待完善内容：

- [ ] showText，需要组件tooltip
- [ ] icon大小设置，icon自定义


问题：
1. 在实现rate组件的过程中，需要用到的color类型为string或Array<string>【tdesign统一给定】，对rate的颜色进行设置
```JSX
import { h, tag, WeElement } from 'omi'

import '../index'

@tag('rate-base')
export default class RateBase extends WeElement {
  render() {
    return <t-rate default-value={3} color={['#000', '#3281b0']}></t-rate>
  }
}
```
如期望实现如下效果： 
![image](https://github.com/Tencent/omi/assets/48597370/8bf2ca04-5653-4be7-81c5-a77078e50011)

目前只能在propTypes注释掉color去实现