### PR TITLE
feat: add grid

### DIFF
--- a/tdesign/desktop/src/divider/divider.tsx
+++ b/tdesign/desktop/src/divider/divider.tsx
@@ -30,7 +30,6 @@ export default class Divider extends WeElement<DividerProps> {
       [`${classPrefix}-divider--with-text`]: showText,
       [`${classPrefix}-divider--with-text-${props.align}`]: showText,
     })
-    console.log('props.children', props.children)
     return (
       <>
         <div class={dividerClassNames} style={props.style}>

--- a/tdesign/desktop/src/grid/_example/base.tsx
+++ b/tdesign/desktop/src/grid/_example/base.tsx
@@ -1,0 +1,31 @@
+import { h, tag, WeElement } from 'omi'
+
+import '../index'
+import * as css from '../style/index'
+const demoCols = [
+  Array(12).fill(1),
+  Array(6).fill(2),
+  Array(4).fill(3),
+  Array(3).fill(4),
+  Array(2).fill(6),
+  Array(1).fill(12),
+]
+@tag('grid-base')
+export default class GridBase extends WeElement {
+  static css = css
+  render() {
+    return (
+      <div style={{ width: '200px' }}>
+        {demoCols.map((cols, i) => (
+          <t-row>
+            {cols.map((col, j) => (
+              <t-col span={col}>
+                <div>{col}</div>
+              </t-col>
+            ))}
+          </t-row>
+        ))}
+      </div>
+    )
+  }
+}

--- a/tdesign/desktop/src/grid/col.tsx
+++ b/tdesign/desktop/src/grid/col.tsx
@@ -1,0 +1,131 @@
+import { h, tag, WeElement, OmiProps, classNames } from 'omi'
+import { ColProps, RowProps } from './type'
+import css from './style/index'
+import isObject from 'lodash/isObject';
+type FlexType = number | 'none' | 'auto' | string;
+
+const calcColPadding = (gutter: RowProps['gutter'], currentSize: string) => {
+    const paddingObj = {};
+    if (typeof gutter === 'number') {
+      Object.assign(paddingObj, {
+        paddingLeft: `${gutter / 2}px`,
+        paddingRight: `${gutter / 2}px`,
+      });
+    } else if (Array.isArray(gutter) && gutter.length) {
+      if (typeof gutter[0] === 'number') {
+        Object.assign(paddingObj, {
+          paddingLeft: `${gutter[0] / 2}px`,
+          paddingRight: `${gutter[0] / 2}px`,
+        });
+      }
+  
+      if (isObject(gutter[0]) && gutter[0][currentSize]) {
+        Object.assign(paddingObj, {
+          paddingLeft: `${gutter[0][currentSize] / 2}px`,
+          paddingRight: `${gutter[0][currentSize] / 2}px`,
+        });
+      }
+    } else if (isObject(gutter) && gutter[currentSize]) {
+      Object.assign(paddingObj, {
+        paddingLeft: `${gutter[currentSize] / 2}px`,
+        paddingRight: `${gutter[currentSize] / 2}px`,
+      });
+    }
+    return paddingObj;
+  };
+  
+const parseFlex = (flex: FlexType) => {
+    if (typeof flex === 'number') {
+        return `${flex} ${flex} auto`;
+    }
+
+    if (/^\d+(\.\d+)?(px|r?em|%)$/.test(flex)) {
+        return `0 0 ${flex}`;
+    }
+
+    return flex;
+};
+
+@tag('t-col')
+export default class Col extends WeElement<ColProps> {
+  static css = css as string
+
+  static defaultProps = { offset: 0, order: 0, pull: 0, push: 0, tag: 'div' };
+
+  static propTypes = {
+    flex: [String, Number],
+    lg: [Number, Object],
+    md: [Number, Object],
+    offset: Number,
+    order: Number,
+    pull: Number,
+    push: Number,
+    sm: [Number, Object],
+    span: Number,
+    tag: String,
+    xl: [Number, Object],
+    xs: [Number, Object],
+    xxl: [Number, Object],
+  }
+  inject = [
+    'gutter', 'size'
+  ]
+  render(props: OmiProps<ColProps>) {
+    const {
+        flex,
+        offset,
+        order,
+        pull,
+        push,
+        span,
+        tag,
+        class,
+        children,
+        style,
+        ...otherColProps
+      } = props
+    const classPrefix = 't'
+    const allSizes = ['xs', 'sm', 'md', 'lg', 'xl', 'xxl'];
+    const sizeClasses = allSizes.reduce((acc, currSize) => {
+        const sizeProp = props[currSize];
+        let sizeObj: any = {};
+        if (typeof sizeProp === 'number') {
+          sizeObj.span = sizeProp;
+        } else if (isObject(sizeProp)) {
+          sizeObj = sizeProp || {};
+        }
+    
+        return {
+          ...acc,
+          [`${classPrefix}-col-${currSize}-${sizeObj.span}`]: sizeObj.span !== undefined,
+          [`${classPrefix}-col-${currSize}-order-${sizeObj.order}`]: parseInt(sizeObj.order, 10) >= 0,
+          [`${classPrefix}-col-${currSize}-offset-${sizeObj.offset}`]: parseInt(sizeObj.offset, 10) >= 0,
+          [`${classPrefix}-col-${currSize}-push-${sizeObj.push}`]: parseInt(sizeObj.push, 10) >= 0,
+          [`${classPrefix}-col-${currSize}-pull-${sizeObj.pull}`]: parseInt(sizeObj.pull, 10) >= 0,
+        };
+      }, {});
+    const colClassNames = classNames(
+        `${classPrefix}-col`,
+        props.class,
+        {
+          [`${classPrefix}-col-${span}`]: span !== undefined,
+          [`${classPrefix}-col-offset-${offset}`]: parseInt(offset as unknown as string, 10) >= 0,
+          [`${classPrefix}-col-pull-${pull}`]: parseInt(pull as unknown as string, 10) >= 0,
+          [`${classPrefix}-col-push-${push}`]: parseInt(push as unknown as string, 10) >= 0,
+          [`${classPrefix}-col-order-${order}`]: parseInt(order as unknown as string, 10) >= 0,
+        },
+        sizeClasses,
+      );
+
+      const colStyle = {
+        ...calcColPadding(this.injection.gutter, this.injection.size),
+        ...style
+      };
+      flex && (colStyle.flex = parseFlex(flex));
+    return (
+        <props.tag class={colClassNames} style={colStyle} {...otherColProps}>
+            {children}
+        </props.tag>
+    )
+  }
+}

--- a/tdesign/desktop/src/grid/index.html
+++ b/tdesign/desktop/src/grid/index.html
@@ -1,0 +1,7 @@
+<html>
+  <script type="module" src="_example/base.tsx"></script>
+</html>
+
+<body>
+  <grid-base></grid-base>
+</body>

--- a/tdesign/desktop/src/grid/index.ts
+++ b/tdesign/desktop/src/grid/index.ts
@@ -1,0 +1,8 @@
+import _Row from './row'
+import _Col from './col'
+
+import './style/index.js'
+export * from './type'
+
+export const Row = _Row
+export const Col = _Col

--- a/tdesign/desktop/src/grid/row.tsx
+++ b/tdesign/desktop/src/grid/row.tsx
@@ -1,0 +1,140 @@
+import { h, tag, WeElement, OmiProps, classNames } from 'omi'
+import {  RowProps } from './type'
+import isObject from 'lodash/isObject';
+import css from './style/index'
+import { canUseDocument, getCssVarsValue } from '../utils/dom';
+
+
+const calcSize = (width: number) => {
+    const smWidth = getCssVarsValue('--td-screen-sm') || 768;
+    const mdWidth = getCssVarsValue('--td-screen-md') || 992;
+    const lgWidth = getCssVarsValue('--td-screen-lg') || 1200;
+    const xlWidth = getCssVarsValue('--td-screen-xl') || 1400;
+    const xxlWidth = getCssVarsValue('--td-screen-xxl') || 1880;
+
+    let size = 'xs';
+    if (width >= xxlWidth) {
+      size = 'xxl';
+    } else if (width >= xlWidth) {
+      size = 'xl';
+    } else if (width >= lgWidth) {
+      size = 'lg';
+    } else if (width >= mdWidth) {
+      size = 'md';
+    } else if (width >= smWidth) {
+      size = 'sm';
+    } else {
+      size = 'xs';
+    }
+    return size;
+  };
+
+const calcRowStyle = (gutter: RowProps['gutter'], currentSize: string): object => {
+    const rowStyle = {};
+    if (typeof gutter === 'number') {
+      Object.assign(rowStyle, {
+        marginLeft: `${gutter / -2}px`,
+        marginRight: `${gutter / -2}px`,
+      });
+    } else if (Array.isArray(gutter) && gutter.length) {
+      if (typeof gutter[0] === 'number') {
+        Object.assign(rowStyle, {
+          marginLeft: `${gutter[0] / -2}px`,
+          marginRight: `${gutter[0] / -2}px`,
+        });
+      }
+      if (typeof gutter[1] === 'number') {
+        Object.assign(rowStyle, { rowGap: `${gutter[1]}px` });
+      }
+  
+      if (isObject(gutter[0]) && gutter[0][currentSize] !== undefined) {
+        Object.assign(rowStyle, {
+          marginLeft: `${gutter[0][currentSize] / -2}px`,
+          marginRight: `${gutter[0][currentSize] / -2}px`,
+        });
+      }
+      if (isObject(gutter[1]) && gutter[1][currentSize] !== undefined) {
+        Object.assign(rowStyle, { rowGap: `${gutter[1][currentSize]}px` });
+      }
+    } else if (isObject(gutter) && gutter[currentSize]) {
+      if (Array.isArray(gutter[currentSize]) && gutter[currentSize].length) {
+        Object.assign(rowStyle, {
+          marginLeft: `${gutter[currentSize][0] / -2}px`,
+          marginRight: `${gutter[currentSize][0] / -2}px`,
+        });
+        Object.assign(rowStyle, { rowGap: `${gutter[currentSize][1]}px` });
+      } else {
+        Object.assign(rowStyle, {
+          marginLeft: `${gutter[currentSize] / -2}px`,
+          marginRight: `${gutter[currentSize] / -2}px`,
+        });
+      }
+    }
+    return rowStyle;
+  };
+
+@tag('t-row')
+export default class Row extends WeElement<RowProps> {
+  static css = css as string
+
+  static defaultProps = { align: 'top', gutter: 0, justify: 'start', tag: 'div' };
+
+  static propTypes = {
+    align: String,
+    gutter: [Number, Object, Array],
+    justify: String,
+    tag: String,
+    class: String,
+    style: Object
+  }
+
+  size = canUseDocument ? calcSize(window.innerWidth) : 'md'
+  updateSize = () => {
+    const currentSize = calcSize(window.innerWidth)
+    if(currentSize !== this.size) {
+        //???
+        this.update()
+    }
+  }
+
+  install() {
+    window.addEventListener('resize', this.updateSize)
+  }
+
+  unintall() {
+    window.removeEventListener('resize', this.updateSize)
+  }
+  
+  provide = {
+    gutter: this.props.gutter,
+    size: this.size
+  }
+
+  render(props: OmiProps<RowProps>) {
+    const {
+        align,
+        gutter,
+        justify,
+        tag,
+        children,
+        class,
+        style,
+        ...otherRowProps} = props
+    const classPrefix = 't'
+    const rowClassNames = classNames(`${classPrefix}-row`, props.class, {
+        [`${classPrefix}-row-${props.justify}`]: true,
+        [`${classPrefix}-row-${props.align}`]: true
+    })
+
+    const rowStyle = {
+        ...calcRowStyle(props.gutter, this.size),
+        // ...{props.style ? props.style : {}}
+    }
+
+    return (
+        <props.tag class={rowClassNames} style={rowStyle} {...otherRowProps} >
+            {children}
+        </props.tag>
+    )
+  }
+}

--- a/tdesign/desktop/src/grid/style/index.ts
+++ b/tdesign/desktop/src/grid/style/index.ts
@@ -1,0 +1,3 @@
+import gridStyle from '../../_common/style/web/components/grid/_index.less'
+import theme from '../../_common/style/web/theme/_index.less'
+export default gridStyle + theme

--- a/tdesign/desktop/src/grid/type.ts
+++ b/tdesign/desktop/src/grid/type.ts
@@ -1,0 +1,97 @@
+/* eslint-disable */
+export interface RowProps {
+  /**
+   * 纵向对齐方式，CSS 属性 `align-items` 值。其中 `top` 和 `start` 等效；`middle` 和 `center` 等效；`bottom` 和 `end` 等效
+   * @default top
+   */
+  align?: 'start' | 'end' | 'center' | 'stretch' | 'baseline' | 'top' | 'middle' | 'bottom'
+  /**
+   * 栅格间隔，示例：`{ xs: 8, sm: 16, md: 24}`。当数据类型为 Number 和 Object 时，用于指定横向间隔。当数据类型为数组时，第一个参数为横向间隔，第二个参数为纵向间隔， [水平间隔, 垂直间隔]
+   * @default 0
+   */
+  gutter?: number | GutterObject | Array<GutterObject | number>
+  /**
+   * flex 布局下的水平排列方式
+   * @default start
+   */
+  justify?: 'start' | 'end' | 'center' | 'space-around' | 'space-between'
+  /**
+   * 自定义元素标签
+   * @default div
+   */
+  tag?: string
+}
+
+export interface ColProps {
+  /**
+   * flex 布局填充。CSS 属性 flex 值。示例：2 / 3 / '100px' / 'auto' / '1 1 200px'
+   */
+  flex?: string | number
+  /**
+   * ≥1200px 响应式栅格，可为栅格数或一个包含其他属性的对象（小尺寸电脑）
+   */
+  lg?: number | BaseColProps
+  /**
+   * ≥992px 响应式栅格，可为栅格数或一个包含其他属性的对象（超小尺寸电脑）
+   */
+  md?: number | BaseColProps
+  /**
+   * 栅格左侧的间隔格数，间隔内不可以有栅格
+   * @default 0
+   */
+  offset?: number
+  /**
+   * 栅格顺序，flex 布局模式下有效
+   * @default 0
+   */
+  order?: number
+  /**
+   * 栅格向左移动格数
+   * @default 0
+   */
+  pull?: number
+  /**
+   * 栅格向右移动格数
+   * @default 0
+   */
+  push?: number
+  /**
+   * ≥768px 响应式栅格，可为栅格数或一个包含其他属性的对象（平板）
+   */
+  sm?: number | BaseColProps
+  /**
+   * 栅格占位格数，为 0 时相当于 display: none
+   */
+  span?: number
+  /**
+   * 自定义元素标签
+   * @default div
+   */
+  tag?: string
+  /**
+   * ≥1400px 响应式栅格，可为栅格数或一个包含其他属性的对象（中尺寸电脑）
+   */
+  xl?: number | BaseColProps
+  /**
+   * <768px 响应式栅格，可为栅格数或一个包含其他属性的对象（手机）
+   */
+  xs?: number | BaseColProps
+  /**
+   * ≥1880px 响应式栅格，可为栅格数或一个包含其他属性的对象（大尺寸电脑）
+   */
+  xxl?: number | BaseColProps
+}
+
+export interface GutterObject {
+  xs: number
+  sm: number
+  md: number
+}
+
+export interface BaseColProps {
+  offset: number
+  order: number
+  pull: number
+  push: number
+  span: number
+}

--- a/tdesign/desktop/src/grid/vite.config.js
+++ b/tdesign/desktop/src/grid/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite'
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  esbuild: {
+    jsxFactory: 'h',
+    jsxFragment: 'h.f',
+  },
+})

--- a/tdesign/desktop/src/utils/dom.ts
+++ b/tdesign/desktop/src/utils/dom.ts
@@ -1,0 +1,10 @@
+// 用于判断是否可使用 dom
+export const canUseDocument = !!(typeof window !== 'undefined' && window.document && window.document.createElement)
+
+// 获取 css vars
+export const getCssVarsValue = (name: string, element?: HTMLElement) => {
+  if (!canUseDocument) return
+
+  const el = element || document.documentElement
+  return getComputedStyle(el).getPropertyValue(name)
+}


### PR DESCRIPTION
初步完成grid代码，未生效样式还待研究


参考tdesign-react实现过程遇到的问题：
- [ ] 由于\<t-col\>也会作为一个dom元素出现在html中，相当于内部div的父元素，因此内部div的flex没有办法按预期展示
![image](https://github.com/Tencent/omi/assets/48597370/7ab2199e-5e6a-4860-9ee7-02c3f19e26f3)

直接把类名赋值给<t-col>可以解决flex未生效问题，但感觉这样实现不够合理
![image](https://github.com/Tencent/omi/assets/48597370/2c2347d6-fdf6-4bc3-b7f9-11babf25b197)

- [ ] 通过style传递的样式，会先在\<t-col\>上作用
- [ ] 无法在组件外部通过声明class修改样式