### PR TITLE
add fire param<options>,support bubbles and composed

### DIFF
--- a/packages/omi/src/component.ts
+++ b/packages/omi/src/component.ts
@@ -376,18 +376,21 @@ export class Component extends HTMLElement {
     })
   }
 
-  fire(name: string, data: unknown): void {
+  fire(name: string, data: unknown,options?:{bubbles: boolean,composed: boolean}): void {
+    const {bubbles,composed} = Object.assign({{bubbles: false,composed:false},options)
     const handler = this.props[`on${capitalize(name)}`] as Function
     if (handler) {
       handler(
         new CustomEvent(name, {
           detail: data,
+          bubbles,composed
         }),
       )
     } else {
       this.dispatchEvent(
         new CustomEvent(name, {
           detail: data,
+          bubbles,composed
         }),
       )
     }


### PR DESCRIPTION
bubbles 和 composed 是在创建 CustomEvent 时可以设置的两个参数，它们都与事件的传播有关。

`bubbles`：这个参数决定了事件是否会冒泡。如果 bubbles 为 true，那么事件会从触发事件的元素开始，向上通过 DOM 树传播，直到到达根元素。如果 bubbles 为 false，那么事件不会冒泡，只会在触发事件的元素上触发。

`composed`：这个参数决定了事件是否可以穿越 Shadow DOM 的边界。如果 composed 为 true，那么事件可以从 Shadow DOM 内部传播到外部，或者从外部传播到内部。如果 composed 为 false，那么事件只会在 Shadow DOM 内部传播，不能穿越 Shadow DOM 的边界。

目前`fire`方法不支持此参数，在创建组件时只能采用原生方法来创建和触发事件

本提交为`fire`增加`bubbles`和`composed`两个额外的选项。

- `fire("myevent",data,{bubble:true})  `
- - `fire("myevent",data,{composed:true}) `