### PR TITLE
feat: Add the function of automatically forwarding ref

### DIFF
--- a/packages/omi/src/component.ts
+++ b/packages/omi/src/component.ts
@@ -6,6 +6,7 @@ import {
   createStyleSheet,
   getClassStaticValue,
   isObject,
+  createRef
 } from './utils'
 import { diff } from './diff'
 import { ExtendedElement } from './dom'
@@ -46,7 +47,7 @@ export class Component<State = any> extends HTMLElement {
       type: Object,
     }
   }
-  
+
   // 可以延迟定义，防止 import { }  被 tree-shaking 掉
   static define(name: string): void {
     define(name, this)

--- a/packages/omi/src/component.ts
+++ b/packages/omi/src/component.ts
@@ -5,6 +5,7 @@ import {
   capitalize,
   createStyleSheet,
   getClassStaticValue,
+  isObject,
 } from './utils'
 import { diff } from './diff'
 import { ExtendedElement } from './dom'
@@ -38,7 +39,14 @@ export class Component<State = any> extends HTMLElement {
   static css: CSSItem | CSSItem[]
   static isLightDOM: boolean
   static noSlot: boolean
-
+  
+  // 被所有组件继承
+  static props = {
+    ref:{
+      type: Object,
+    }
+  }
+  
   // 可以延迟定义，防止 import { }  被 tree-shaking 掉
   static define(name: string): void {
     define(name, this)
@@ -53,6 +61,8 @@ export class Component<State = any> extends HTMLElement {
   injection?: { [key: string]: unknown }
   renderRoot?: ExtendedElement | ShadowRoot | Component
   rootElement: ExtendedElement | ExtendedElement[] | null
+
+  _ref :Partial<Record<'current', any>>= null
 
   constructor() {
     super()
@@ -87,6 +97,16 @@ export class Component<State = any> extends HTMLElement {
     this.rootElement = null
   }
 
+  get ref(){
+    if(!this._ref){
+      if(this.props.ref && isObject(this.props.ref)){
+        this._ref = this.props.ref 
+      }else{
+        this._ref = createRef()
+      }
+    }
+    return this._ref
+  }
   /**
    * 处理props
    *


### PR DESCRIPTION
现在`omi`缺少类似`React`的`forwardRef`功能，如果要实现类型的功能，需要自行通过自行声明`props.ref`来层层传递，当在多级组件时非常麻烦，本次提交增加了自动转发`ref`的特性。


## 本次提交前

```tsx
@tag("my-parent")
class Parent extends Component{
static props={
    ref: {
      type：Object
    }
 }
 render(props){
     return <my-child ref={props.ref}/>
 }
}


@tag("my-child")
class Parent extends Component{
static props={
    ref: {
      type：Object
    }
 }
 render(props){
     return <div ref={props.ref}/>
 }
}
 

@tag("my-app")
class MyApp extends Component{
ref=createRef()
render(){
    return <my-parent ref={this.ref}/>》
}
```

## 本次提交后


```ts
@tag("my-parent")
class Parent extends Component{

 render(props){
     return <my-child/>   // 不需要转发ref
 }
}


@tag("my-child")
class Parent extends Parent { 
 render(props){
     return <div ref={this.ref}/>  // 通过this.ref可以得到父组件乃至祖先组件的传入的ref
  }
}


@tag("my-app")
class MyApp extends Component{
ref=createRef()
render(){
    return <my-parent ref={this.ref}/>》
}

```

## 工作原理

基本实现原理是基本`7.6.10`版本新增加的组件继承机制，在`Component`类中增加了以下代码：

```diff
class Component{ 
+  static props = {
+    ref:{
+      type: Object,
+    }
+  }
+   _ref :Partial<Record<'current', any>>= null
+   get ref(){
+     if(!this._ref){
+       if(this.props.ref && isObject(this.props.ref)){
+         this._ref = this.props.ref 
+       }else{
+         this._ref = createRef()
+       }
+     }
+     return this._ref
+   }
}
```

由于组件在继承时会读取继承链上的props，所以所有的组件均会拥有一个`ref`的`prop`，所以可以实现自动读取父或祖先组件的`ref`，并且`this._ref`仅在使用到时才会生效。







