### PR TITLE
feat(omi-templates): finish education templates

### DIFF
--- a/packages/omi-templates/package-lock.json
+++ b/packages/omi-templates/package-lock.json
@@ -16,6 +16,7 @@
         "echarts": "^5.5.0",
         "markdown-it": "^14.0.0",
         "omi": "7.6.7",
+        "omi-ripple": "^0.1.2",
         "omi-router": "latest",
         "omi-suspense": "latest",
         "prismjs": "^1.29.0",
@@ -2159,6 +2160,14 @@
         "construct-style-sheets-polyfill": "3.0.1",
         "reactive-signal": "^1.0.3",
         "weakmap-polyfill": "2.0.4"
+      }
+    },
+    "node_modules/omi-ripple": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmmirror.com/omi-ripple/-/omi-ripple-0.1.2.tgz",
+      "integrity": "sha512-kgV5Jb8RVQm1n+xPA2yzexOnFfsygeoC33EmolSW3GlAbnTga20c0HgRyh4v9h/kqm+HqXKt478DqNCMk+ukdw==",
+      "dependencies": {
+        "omi": "latest"
       }
     },
     "node_modules/omi-router": {
@@ -4878,6 +4887,14 @@
         "construct-style-sheets-polyfill": "3.0.1",
         "reactive-signal": "^1.0.3",
         "weakmap-polyfill": "2.0.4"
+      }
+    },
+    "omi-ripple": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmmirror.com/omi-ripple/-/omi-ripple-0.1.2.tgz",
+      "integrity": "sha512-kgV5Jb8RVQm1n+xPA2yzexOnFfsygeoC33EmolSW3GlAbnTga20c0HgRyh4v9h/kqm+HqXKt478DqNCMk+ukdw==",
+      "requires": {
+        "omi": "latest"
       }
     },
     "omi-router": {

--- a/packages/omi-templates/package.json
+++ b/packages/omi-templates/package.json
@@ -20,6 +20,7 @@
     "echarts": "^5.5.0",
     "markdown-it": "^14.0.0",
     "omi": "7.6.7",
+    "omi-ripple": "^0.1.2",
     "omi-router": "latest",
     "omi-suspense": "latest",
     "prismjs": "^1.29.0",

--- a/packages/omi-templates/src/components/omiu/swiper/api.md
+++ b/packages/omi-templates/src/components/omiu/swiper/api.md
@@ -1,34 +1,37 @@
 ## Swiper Props
 
-| Name       | Type    | Default      | Description                                      |
-| ---------- | ------- | ------------ | ------------------------------------------------ |
-| direction  | string  | 'horizontal' | Direction of the swiper (vertical or horizontal) |
-| loop       | boolean | true         | Whether the swiper should loop                   |
-| index      | number  | 0            | Initial index of the swiper                      |
-| navigation | boolean | true         | Whether to show navigation buttons               |
-| pagination | boolean | true         | Whether to show pagination                       |
+| Name          | Type    | Default      | Description                                      |
+| ------------- | ------- | ------------ | ------------------------------------------------ |
+| direction     | string  | 'horizontal' | Direction of the swiper (vertical or horizontal) |
+| loop          | boolean | true         | Whether the swiper should loop                   |
+| index         | number  | 0            | Initial index of the swiper                      |
+| navigation    | boolean | true         | Whether to show navigation buttons               |
+| pagination    | boolean | true         | Whether to show pagination                       |
 | slidesPerView | string or number | "auto" | Number of slides to show per view. "auto" will automatically adjust the number of slides based on the viewport size. |
-| spaceBetween | number | 30 | Space between each slide in pixels. |
-| autoPlay | boolean | true | Whether to enable auto play. |
+| spaceBetween  | number  | 30           | Space between each slide in pixels.              |
+| autoPlay      | boolean | true         | Whether to enable auto play.                     |
 
 ## Swiper Events
 
-| Name   | Parameters               | Description                        |
-| ------ | ------------------------ | ---------------------------------- |
-| change | evt: CustomEvent<number> | Event triggered when slide changes |
+| Name   | Parameters                   | Description                           |
+| ------ | ---------------------------- | ------------------------------------- |
+| change | evt: CustomEvent<number>     | Event triggered when slide changes    |
 
 ## Swiper 属性
 
-| Name       | Type   | Default      | Description                 |
-| ---------- | ------ | ------------ | --------------------------- |
-| direction  | 字符串 | 'horizontal' | Swiper 的方向（垂直或水平） |
-| loop       | 布尔值 | true         | 是否启用 Swiper 循环播放    |
-| index      | 数字   | 0            | Swiper 的初始索引           |
-| navigation | 布尔值 | true         | 是否显示导航按钮            |
-| pagination | 布尔值 | true         | 是否显示分页器              |
+| 名称         | 类型    | 默认值       | 描述                                          |
+| ------------ | ------- | ------------ | --------------------------------------------- |
+| direction    | 字符串  | 'horizontal' | Swiper 的方向（垂直或水平）                   |
+| loop         | 布尔值  | true         | 是否启用 Swiper 循环播放                      |
+| index        | 数字    | 0            | Swiper 的初始索引                            |
+| navigation   | 布尔值  | true         | 是否显示导航按钮                             |
+| pagination   | 布尔值  | true         | 是否显示分页器                               |
+| slidesPerView| 字符串或数字 | "auto"    | 每视图显示的幻灯片数量。"auto" 根据视口大小自动调整幻灯片数量。 |
+| spaceBetween | 数字    | 30           | 每个幻灯片之间的间距（像素）。                 |
+| autoPlay     | 布尔值  | true         | 是否启用自动播放                              |
 
 ## Swiper 事件
 
-| Name   | Parameter                | Description            |
-| ------ | ------------------------ | ---------------------- |
-| change | evt: CustomEvent<number> | 幻灯片更改时触发的事件 |
+| 名称    | 参数                       | 描述                               |
+| ------ | -------------------------- | ---------------------------------- |
+| change | evt: CustomEvent<number>   | 幻灯片更改时触发的事件             |

--- a/packages/omi-templates/src/components/omiu/swiper/swiper.tsx
+++ b/packages/omi-templates/src/components/omiu/swiper/swiper.tsx
@@ -1,5 +1,4 @@
 import { tag, Component, classNames, OmiProps, bind, VNode } from 'omi'
-import { tailwind } from '@/tailwind'
 // import '../collapse/collapse'
 
 
@@ -39,7 +38,6 @@ const theme = {
 @tag('o-swiper')
 export class SwiperComponent extends Component<Props> {
   static css = [
-    tailwind,
     swiperStyle,
     `:host {
     display: block;

--- a/packages/omi-templates/src/components/omiu/swiper/swiper.tsx
+++ b/packages/omi-templates/src/components/omiu/swiper/swiper.tsx
@@ -23,7 +23,7 @@ interface Props {
   navigation?: boolean
   slidesPerView?: "auto" | number
   spaceBetween?: number,
-  autoplay?:  boolean
+  autoplay?:  boolean | number
 }
 
 const theme = {
@@ -79,7 +79,7 @@ export class SwiperComponent extends Component<Props> {
     pagination: true,
     slidesPerView: 1,
     spaceBetween: 30,
-    autoplay: 1000
+    autoplay: true
   }
 
   swiper: Swiper | null = null
@@ -92,7 +92,10 @@ export class SwiperComponent extends Component<Props> {
       initialSlide: this.props.index,
       slidesPerView: this.props.slidesPerView,
       spaceBetween:this.props.spaceBetween,
-      autoplay:this.props.autoplay
+      autoplay:this.props.autoplay,
+      observer: true,
+      observeParents: true
+  
       // And if we need scrollbar
       // scrollbar: {
       //   el: '.swiper-scrollbar',
@@ -110,6 +113,32 @@ export class SwiperComponent extends Component<Props> {
     this.swiper.on('slideChange', () => {
       this.setActiveButton(this.swiper!.realIndex)
     })
+
+    if (this.swiper.autoplay){
+      // 判断是boolean类型还是number类型，设定定时器调用slideChange事件
+      console.log('swiper autoplay',this.swiper.autoplay)
+      this.swiper.update()
+    }
+
+    // 自定义实现：随窗口大小动态设置同时展示的slide，
+    // 原swiper组件会因为封装多的一层swiper-wrapper影响判断swiper-slide的宽度
+    const updateSlidesPerView = () => {
+      let slidesPerView = 1
+      if (window.innerWidth >= 1440) {
+        slidesPerView = 3
+      } else if (window.innerWidth >= 768) {
+        slidesPerView = 2
+      }
+      if (this.swiper){
+        this.swiper.params.slidesPerView = slidesPerView
+        this.swiper.update()  
+      }
+    }
+
+    if (this.props.slidesPerView === 'auto') {
+      updateSlidesPerView()
+      window.addEventListener('resize', updateSlidesPerView)
+    }
   }
 
   setActiveButton(index: number) {

--- a/packages/omi-templates/src/pages/education.tsx
+++ b/packages/omi-templates/src/pages/education.tsx
@@ -205,10 +205,10 @@ class EducationTemplate extends Component {
 
                     <div class="p-4">
                       <div class="flex justify-between items-center">
-                        <span class="dark:text-foreground text-sm">
+                        <span class="text-zinc-600 dark:text-foreground text-sm">
                           <i class="far fa-calendar"></i> {course.date}
                         </span>
-                        <span class="dark:text-foreground text-sm">
+                        <span class="text-zinc-600 dark:text-foreground text-sm">
                           <i class="far fa-clock"></i> {course.duration}
                         </span>
                       </div>
@@ -240,7 +240,7 @@ class EducationTemplate extends Component {
         {/** 名师风采 */}
         <section class="container mx-auto p-6">
           <h1 class="text-3xl font-bold mb-1 text-center">名师风采</h1>
-          <p class="text-lg dark:text-foreground mb-4 text-center">
+          <p class="text-lg text-zinc-600 dark:text-foreground mb-4 text-center">
             我们骄傲地介绍我们的优秀教师团队，他们在各自的领域拥有丰富的经验和卓越的成就。
           </p>
           <o-swiper
@@ -256,7 +256,7 @@ class EducationTemplate extends Component {
                 <img src={teacher.image} alt={teacher.name} class="w-48 rounded object-cover object-center mb-4" />
                 <h2 class="text-xl font-semibold">{teacher.name}</h2>
                 <h3 class="text-lg dark:text-foreground">{teacher.title}</h3>
-                <p class="dark:text-foreground mt-2">{teacher.description}</p>
+                <p class="text-zinc-600 dark:text-foreground mt-2">{teacher.description}</p>
               </div>
             ))}
           </o-swiper>
@@ -275,7 +275,7 @@ class EducationTemplate extends Component {
                 />
                 <h2 class="text-xl font-semibold">{student.name}</h2>
                 <h3 class="text-lg dark:text-foreground">{student.title}</h3>
-                <p class="text-center">{student.description}</p>
+                <p class="text-zinc-600 ">{student.description}</p>
               </div>
             ))}
           </o-swiper>

--- a/packages/omi-templates/src/pages/education.tsx
+++ b/packages/omi-templates/src/pages/education.tsx
@@ -1,7 +1,7 @@
 import { render, signal, tag, Component } from 'omi'
 import '../components/omiu/button'
 import '../components/omiu/swiper/swiper'
-
+import 'omi-ripple'
 // 分类数据
 const categories = signal([
   { name: '前端开发' },
@@ -104,11 +104,10 @@ let teachers = [
     description: '前端开发的专家，特别擅长Vue.js框架的应用与开发。',
     image: 'https://omi.cdn-go.cn/admin/latest/home/omi.svg',
   },
-];
-
+]
 
 // 学生评价 数据
-const studentReviews = [
+var studentReviews = [
   {
     name: '学生A',
     title: '前端开发工程师',
@@ -133,11 +132,27 @@ const studentReviews = [
     description: '《数据分析与可视化》课程让我学习到了如何将数据转化为有价值的见解，对我的工作非常有帮助。',
     image: 'http://yywebsite.cn/assets/img/edu/student1.jpg',
   },
-];
+]
 
 @tag('education-template')
 class EducationTemplate extends Component {
   activeCategory: string = '全部'
+
+  static css = [
+    `
+    o-button {
+      position: relative;
+      overflow: hidden;
+      transition: background 400ms;
+      font-size: 1.5rem;
+      outline: 0;
+      border: 0;
+      border-radius: 0.25rem;
+      cursor: pointer;
+    }
+  
+    `,
+  ]
 
   // 筛选课程
   filterCourses(category: string) {
@@ -156,9 +171,10 @@ class EducationTemplate extends Component {
             {/* 分类section */}
             <div class="flex justify-around mb-8">
               {['全部', ...categories.value.map((category) => category.name)].map((category, index) => (
-                <o-button   
+                <o-button
                   key={index}
                   variant="text"
+                  o-ripple
                   theme={category === this.activeCategory ? 'primary' : 'default'}
                   onClick={() => {
                     this.activeCategory = category
@@ -176,8 +192,17 @@ class EducationTemplate extends Component {
                 <div class="col-span-full text-center text-foreground">暂无相关课程</div>
               ) : (
                 courses.value.map((course, index) => (
-                  <div key={index} class="max-w-sm mx-auto bg-background rounded-lg overflow-hidden shadow-lg">
-                    <img class="w-full" src={course.image} alt="Course Image" />
+                  <div
+                    key={index}
+                    class="max-w-sm mx-auto bg-background rounded-lg  overflow-hidden shadow-lg"
+                    o-ripple
+                  >
+                    <img
+                      class="w-full object-cover object-center transition-transform duration-300 transform group-hover:scale-105 group-hover:shadow-lg"
+                      src={course.image}
+                      alt="Course Image"
+                    />
+
                     <div class="p-4">
                       <div class="flex justify-between items-center">
                         <span class="dark:text-foreground text-sm">
@@ -218,10 +243,17 @@ class EducationTemplate extends Component {
           <p class="text-lg dark:text-foreground mb-4 text-center">
             我们骄傲地介绍我们的优秀教师团队，他们在各自的领域拥有丰富的经验和卓越的成就。
           </p>
-          <o-swiper class="w-full" direction="horizontal" loop={true} index={0} navigation={false} pagination={true} slidesPerView={"auto"}>
+          <o-swiper
+            class="w-full"
+            direction="horizontal"
+            loop={true}
+            navigation={false}
+            pagination={true}
+            slidesPerView={'auto'}
+          >
             {teachers.map((teacher) => (
-              <div class="m-4 p-8  md:min-w-1/2 sm:w-full flex flex-col items-center bg-background rounded-lg">
-                <img src={teacher.image} alt={teacher.name} class="w-48 rounded object-cover mb-4" />
+              <div class="m-4 p-8 md:min-w-1/2 sm:w-full flex flex-col items-center bg-background rounded-lg transition-transform duration-300 ease-in-out transform hover:-translate-y-2 hover:shadow-lg">
+                <img src={teacher.image} alt={teacher.name} class="w-48 rounded object-cover object-center mb-4" />
                 <h2 class="text-xl font-semibold">{teacher.name}</h2>
                 <h3 class="text-lg dark:text-foreground">{teacher.title}</h3>
                 <p class="dark:text-foreground mt-2">{teacher.description}</p>
@@ -232,11 +264,15 @@ class EducationTemplate extends Component {
 
         {/** 学生课程评价 */}
         <section class="container mx-auto p-6">
-          <h1 class="text-3xl font-bold mb-4 text-center" >学生课程评价</h1>
-          <o-swiper direction="horizontal" loop={true} index={0} navigation={false} pagination={true} slidesPerView={3}>
+          <h1 class="text-3xl font-bold mb-4 text-center">学生课程评价</h1>
+          <o-swiper direction="horizontal" loop={true} navigation={false} pagination={true} slidesPerView={'auto'}>
             {studentReviews.map((student) => (
-              <div class="m-4 p-8 flex flex-col items-center bg-background rounded-lg">
-                <img src={student.image} alt={student.name} class="w-32 h-32 rounded-full mb-4" />
+              <div class="m-4 p-8 flex flex-col items-center bg-background rounded-lg transition-transform duration-300 ease-in-out transform hover:-translate-y-2 hover:shadow-lg">
+                <img
+                  src={student.image}
+                  alt={student.name}
+                  class="w-32 h-32 rounded-full object-cover object-center mb-4"
+                />
                 <h2 class="text-xl font-semibold">{student.name}</h2>
                 <h3 class="text-lg dark:text-foreground">{student.title}</h3>
                 <p class="text-center">{student.description}</p>

--- a/packages/omi-templates/src/pages/education.tsx
+++ b/packages/omi-templates/src/pages/education.tsx
@@ -166,7 +166,7 @@ class EducationTemplate extends Component {
   render() {
     return (
       <div>
-        <section id="courses" class="py-12">
+        <section id="courses" class="py-12  p-6">
           <div class="container mx-auto">
             {/* 分类section */}
             <div class="flex justify-around mb-8">


### PR DESCRIPTION


## 修改点

- feat(swiper): 
   - 增加templates内封装组件swiper的自动轮播功能
   - 依据视口动态调整slidePerView数量


- style(education): 
    - 页面样式优化（引入omi-ripple效果以及卡片悬浮过渡）
    - 手机端的页面适配


## 实现效果

- 自动轮播+ 悬浮暂停

![omi-swiper-2](https://github.com/user-attachments/assets/f103f531-80df-4520-9d6a-e770cd078213)

- 多端适配


<img src="https://github.com/user-attachments/assets/9ba2dd76-f79e-4e0e-b118-75c52dc12998" width="400">

<img src="https://github.com/user-attachments/assets/6e611b1d-bc6d-4f89-b95b-59d3e0ab7b14" width="400">



## 其余点

引入了omi-ripple，更新分支后需`npm install`一下。

```
npm install omi-ripple
```


