### PR TITLE
fix: property support camel case naming

### DIFF
--- a/packages/omi/src/component.ts
+++ b/packages/omi/src/component.ts
@@ -3,6 +3,7 @@ import {
   isArray,
   hyphenate,
   capitalize,
+  camelCase,
   createStyleSheet,
   getClassStaticValue,
   isObject,
@@ -159,11 +160,12 @@ export class Component<State = any> extends HTMLElement {
   }
 
   attributeChangedCallback(name, oldValue, newValue) {
-    if (this.constructor.props && this.constructor.props[name]) {
-      const prop = this.constructor.props[name]
+    const propsName = camelCase(name)
+    if (this.constructor.props && this.constructor.props[propsName]) {
+      const prop = this.constructor.props[propsName]
       if (prop.changed) {
-        const newTypeValue = this.getTypeValueOfProp(name, newValue)
-        const oldTypeValue = this.getTypeValueOfProp(name, oldValue)
+        const newTypeValue = this.getTypeValueofProp(propsName, newValue)
+        const oldTypeValue = this.getTypeValueofProp(propsName, oldValue)
         prop.changed.call(this, newTypeValue, oldTypeValue)
       }
     }
@@ -185,7 +187,7 @@ export class Component<State = any> extends HTMLElement {
   }
 
   static get observedAttributes() {
-    return this.props ? Object.keys(this.props) : []
+    return this.props ? Object.keys(this.props).map(hyphenate) : []
   }
 
   injectObject() {


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/70a2ab59-7203-4f1e-a0fc-f7601c504167)
webComponnet文档示例中属性支持驼峰命名，但实际的实现存在缺陷，驼峰命名的属性无法触发attributeChangedCallback